### PR TITLE
Update readme and example for usage of TF registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,25 @@
 
 Use the 1Password Connect Terraform Provider to reference, create, or update items in your 1Password Vaults.
 
+## Usage
+
+```tf
+terraform {
+  required_providers {
+    onepassword = {
+      source = "1Password/onepassword"
+      version = "~> 1.0.0"
+    }
+  }
+}
+
+provider "onepassword" {
+  url     = "http://<1Password Connect API Hostname>"
+}
+```
+
+See the [examples](./examples/) directory for a full example. 
+
 ## Building
 
 To build the 1Password Connect Terraform provider run the following
@@ -39,8 +58,8 @@ In your Terraform configuration you will need to specify the op plugin with
 terraform {
   required_providers {
     onepassword = {
-      version = "0.2"
       source   = "github.com/1Password/onepassword"
+      version = "~> 1.0.0"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,25 @@ terraform {
 }
 
 provider "onepassword" {
-  url = "http://<1Password Connect API Hostname>"
+  url = "http://localhost:8080"
+}
+
+variable "demo_vault" {
+  default = "fuacthv5i7gextkqv45g7algw8"
+}
+
+resource "onepassword_item" "demo_login" {
+  vault = var.demo_vault
+  
+  title    = "Demo Terraform Login"
+  category = "password"
+
+  username = "demo-username"
+
+  password_recipe {
+    length  = 40
+    symbols = false
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ terraform {
 }
 
 provider "onepassword" {
-  url     = "http://<1Password Connect API Hostname>"
+  url = "http://<1Password Connect API Hostname>"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ provider "onepassword" {
 variable "vault_id" {}
 
 resource "onepassword_item" "demo_login" {
-  vault = var.demo_vault
+  vault = var.vault_id
   
   title    = "Demo Terraform Login"
   category = "password"

--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ provider "onepassword" {
   url = "http://localhost:8080"
 }
 
-variable "demo_vault" {
-  default = "fuacthv5i7gextkqv45g7algw8"
-}
+variable "vault_id" {}
 
 resource "onepassword_item" "demo_login" {
   vault = var.demo_vault

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,9 +20,13 @@ $ terraform init
 Initializing the backend...
 
 Initializing provider plugins...
-- Finding github.com/1password/onepassword versions matching "0.1.0"...
-- Installing github.com/1password/onepassword v0.1.0...
-- Installed github.com/1password/onepassword v0.1.0 (unauthenticated)
+- Finding 1password/onepassword versions matching "~> 1.0.0"...
+- Installing 1password/onepassword v1.0.0...
+- Installed 1password/onepassword v1.0.0 (signed by a HashiCorp partner, key ID 6681876AE08DC4BF)
+
+Partner and community providers are signed by their developers.
+If you'd like to know more about provider signing, you can read about it here:
+https://www.terraform.io/docs/cli/plugins/signing.html
 
 Terraform has created a lock file .terraform.lock.hcl to record the provider
 selections it made above. Include this file in your version control repository
@@ -38,6 +42,7 @@ should now work.
 If you ever set or change modules or backend configuration for Terraform,
 rerun this command to reinitialize your working directory. If you forget, other
 commands will detect it and remind you to do so if necessary.
+
 $ terraform apply
 
 

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     onepassword = {
-      version = "0.2"
-      source  = "github.com/1Password/onepassword"
+      source = "1Password/onepassword"
+      version = "~> 1.0.0"
     }
   }
 }


### PR DESCRIPTION
Updated versions to `~> 1.0.0` and replaced the GitHub reference with the TF registry name in all but the local usage example.

Resolves #9.