### PR TITLE
Require item to be recreated when changing category or vault

### DIFF
--- a/onepassword/resource_onepassword_item.go
+++ b/onepassword/resource_onepassword_item.go
@@ -72,11 +72,13 @@ func resourceOnepasswordItem() *schema.Resource {
 			"vault": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"category": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "login",
+				ForceNew: true,
 			},
 			"title": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
Supporting any of these values in place is not supported, so we should force the recreation of an item if these fields are changed.

Resolves #13 