### PR TITLE
Set tags when creating/updating item

### DIFF
--- a/onepassword/data_source_onepassword_item_test.go
+++ b/onepassword/data_source_onepassword_item_test.go
@@ -72,6 +72,7 @@ func compareItemToSource(t *testing.T, dataSourceData *schema.ResourceData, item
 	if dataSourceData.Get("url") != item.URLs[0].URL {
 		t.Errorf("Expected url to be %v got %v", item.URLs[0].URL, dataSourceData.Get("url"))
 	}
+	compareStringSlice(t, getTags(dataSourceData), item.Tags)
 
 	for _, f := range item.Fields {
 		path := f.Label
@@ -158,4 +159,17 @@ func generateFields() []*onepassword.ItemField {
 		},
 	}
 	return fields
+}
+
+func compareStringSlice(t *testing.T, actual, expected []string) {
+	t.Helper()
+	if len(actual) != len(expected) {
+		t.Errorf("Expected slice to be length %d, but got %d", len(expected), len(actual))
+		return
+	}
+	for i, val := range expected {
+		if actual[i] != val {
+			t.Errorf("Expected %s at index %d, but got %s", val, i, actual[i])
+		}
+	}
 }

--- a/onepassword/resource_onepassword_item.go
+++ b/onepassword/resource_onepassword_item.go
@@ -375,6 +375,7 @@ func dataToItem(data *schema.ResourceData) (*onepassword.Item, error) {
 				URL:     data.Get("url").(string),
 			},
 		},
+		Tags: getTags(data),
 	}
 
 	password := data.Get("password").(string)
@@ -582,4 +583,13 @@ func addRecipe(f *onepassword.ItemField, r *onepassword.GeneratorRecipe) {
 		len(f.Value) != r.Length {
 		f.Generate = true
 	}
+}
+
+func getTags(data *schema.ResourceData) []string {
+	tagInterface := data.Get("tags").([]interface{})
+	tags := make([]string, len(tagInterface))
+	for i, tag := range tagInterface {
+		tags[i] = tag.(string)
+	}
+	return tags
 }

--- a/onepassword/resource_onepassword_item_test.go
+++ b/onepassword/resource_onepassword_item_test.go
@@ -24,6 +24,30 @@ var schemaKeys = []string{
 	"tags",
 }
 
+func TestResourceItemToDataDataToTitem(t *testing.T) {
+	resources := map[string]*schema.ResourceData{
+		"login":    generateResourceLoginItem(t),
+		"database": generateResourceDatabaseItem(t),
+		"password": generateResourcePasswordItem(t),
+	}
+	for name, resource := range resources {
+		t.Run(name, func(t *testing.T) {
+			item, err := dataToItem(resource)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			compareItemToSource(t, resource, item)
+
+			convertedResource := schema.TestResourceDataRaw(t, resourceOnepasswordItem().Schema, nil)
+
+			itemToData(item, convertedResource)
+
+			compareResources(t, resource, convertedResource)
+		})
+	}
+}
+
 func TestResourceOnepasswordLoginItemCRUD(t *testing.T) {
 	itemToCreate := generateResourceLoginItem(t)
 	testCRUDForItem(t, itemToCreate)

--- a/onepassword/resource_onepassword_item_test.go
+++ b/onepassword/resource_onepassword_item_test.go
@@ -21,6 +21,7 @@ var schemaKeys = []string{
 	"port",
 	"username",
 	"password",
+	"tags",
 }
 
 func TestResourceOnepasswordLoginItemCRUD(t *testing.T) {
@@ -202,6 +203,7 @@ func generateBaseItem(t *testing.T) *schema.ResourceData {
 	resourceData.Set("vault", "df2e9643-45ad-4ff9-8b98-996f801afa75")
 	resourceData.Set("title", "test_login")
 	resourceData.Set("url", "some_url")
+	resourceData.Set("tags", []string{"tag-1", "tag-2"})
 	return resourceData
 }
 
@@ -214,9 +216,15 @@ func generateResource(t *testing.T, item *onepassword.Item) *schema.ResourceData
 }
 
 func compareResources(t *testing.T, expectedResource, actualResource *schema.ResourceData) {
+	t.Helper()
 	for _, key := range schemaKeys {
-		if expectedResource.Get(key) != actualResource.Get(key) {
-			t.Errorf("Expected %v to be %v but was %v", key, actualResource.Get(key), expectedResource.Get(key))
+		if key == "tags" {
+			compareStringSlice(t, getTags(actualResource), getTags(expectedResource))
+		} else {
+			if expectedResource.Get(key) != actualResource.Get(key) {
+				t.Errorf("Expected %v to be %v but was %v", key, actualResource.Get(key), expectedResource.Get(key))
+			}
 		}
+
 	}
 }


### PR DESCRIPTION
As reported in #15, tags were not correctly set on the 1Pasword item when performing an create or update.

Resolves #15.