### PR TITLE
Vault data source

### DIFF
--- a/docs/data-sources/vault.md
+++ b/docs/data-sources/vault.md
@@ -1,0 +1,26 @@
+---
+page_title: "onepassword_vault Data Source - terraform-provider-onepassword"
+subcategory: ""
+description: |-
+  Use this data source to get details of a vault by either its name or uuid.
+---
+
+# Data Source `onepassword_vault`
+
+Use this data source to get details of a vault by either its name or uuid.
+
+
+
+## Schema
+
+### Optional
+
+- **name** (String, Optional) The name of the vault to retrieve.
+- **uuid** (String, Optional) The UUID of the vault to retrieve.
+
+### Read-only
+
+- **description** (String, Read-only) The description of the vault.
+- **id** (String, Read-only) The ID of this resource.
+
+

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/1Password/terraform-provider-onepassword
 go 1.15
 
 require (
-	github.com/1Password/connect-sdk-go v1.0.2-0.20210528135252-bfc6d04506d6
+	github.com/1Password/connect-sdk-go v1.1.0
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/aws/aws-sdk-go v1.37.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/1Password/terraform-provider-onepassword
 go 1.15
 
 require (
-	github.com/1Password/connect-sdk-go v1.0.1
+	github.com/1Password/connect-sdk-go v1.0.2-0.20210528135252-bfc6d04506d6
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/aws/aws-sdk-go v1.37.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -34,10 +34,8 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0 h1:STgFzyU5/8miMl0//zKh2aQeTyeaUH3WN9bSUiJ09bA=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/1Password/connect-sdk-go v1.0.1 h1:BOeMIxVk6/ISmLNWUkSxEbVI7tNr5+aNXIobMM0/I0U=
-github.com/1Password/connect-sdk-go v1.0.1/go.mod h1:br2BWk2sqgJFnOFK5WSDfBBmwQ6E7hV9LoPqrtHGRNY=
-github.com/1Password/connect-sdk-go v1.0.2-0.20210528135252-bfc6d04506d6 h1:/Qc7AA99ikto85H/uLLMkKgD2qWxNYONMmp9te9sKyU=
-github.com/1Password/connect-sdk-go v1.0.2-0.20210528135252-bfc6d04506d6/go.mod h1:0yXJAQtWinciTioZsvrPYTYlhFdEla3WnyDo8xfaSlM=
+github.com/1Password/connect-sdk-go v1.1.0 h1:cIgAu2EiTXRVUCWWytu6bOuTSIMYmZAzO1ES1wMYKFg=
+github.com/1Password/connect-sdk-go v1.1.0/go.mod h1:i4WkvBAjspga39/fW/Aca6b8Shu6El02Wp34kp3ICXQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/HdrHistogram/hdrhistogram-go v1.0.1 h1:GX8GAYDuhlFQnI2fRDHQhTlkHMz8bEn0jTI6LJU0mpw=

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/1Password/connect-sdk-go v1.0.1 h1:BOeMIxVk6/ISmLNWUkSxEbVI7tNr5+aNXIobMM0/I0U=
 github.com/1Password/connect-sdk-go v1.0.1/go.mod h1:br2BWk2sqgJFnOFK5WSDfBBmwQ6E7hV9LoPqrtHGRNY=
+github.com/1Password/connect-sdk-go v1.0.2-0.20210528135252-bfc6d04506d6 h1:/Qc7AA99ikto85H/uLLMkKgD2qWxNYONMmp9te9sKyU=
+github.com/1Password/connect-sdk-go v1.0.2-0.20210528135252-bfc6d04506d6/go.mod h1:0yXJAQtWinciTioZsvrPYTYlhFdEla3WnyDo8xfaSlM=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/HdrHistogram/hdrhistogram-go v1.0.1 h1:GX8GAYDuhlFQnI2fRDHQhTlkHMz8bEn0jTI6LJU0mpw=

--- a/onepassword/data_source_onepassword_item_test.go
+++ b/onepassword/data_source_onepassword_item_test.go
@@ -10,11 +10,11 @@ import (
 )
 
 func TestDataSourceOnePasswordItemRead(t *testing.T) {
-	meta := &testClient{}
 	expectedItem := generateItem()
-
-	DoGetItemFunc = func(uuid string, vaultUUID string) (*onepassword.Item, error) {
-		return expectedItem, nil
+	meta := &testClient{
+		GetItemFunc: func(uuid string, vaultUUID string) (*onepassword.Item, error) {
+			return expectedItem, nil
+		},
 	}
 
 	dataSourceData := generateDataSource(t, expectedItem)
@@ -27,8 +27,12 @@ func TestDataSourceOnePasswordItemRead(t *testing.T) {
 }
 
 func TestDataSourceOnePasswordItemReadWithSections(t *testing.T) {
-	meta := &testClient{}
 	expectedItem := generateItem()
+	meta := &testClient{
+		GetItemFunc: func(uuid string, vaultUUID string) (*onepassword.Item, error) {
+			return expectedItem, nil
+		},
+	}
 	testSection := &onepassword.ItemSection{
 		ID:    "1234",
 		Label: "Test Section",
@@ -41,10 +45,6 @@ func TestDataSourceOnePasswordItemReadWithSections(t *testing.T) {
 		Value:   "Password123",
 		Section: testSection,
 	})
-
-	DoGetItemFunc = func(uuid string, vaultUUID string) (*onepassword.Item, error) {
-		return expectedItem, nil
-	}
 
 	dataSourceData := generateDataSource(t, expectedItem)
 

--- a/onepassword/data_source_onepassword_vault.go
+++ b/onepassword/data_source_onepassword_vault.go
@@ -1,0 +1,82 @@
+package onepassword
+
+import (
+	"fmt"
+
+	"github.com/1Password/connect-sdk-go/connect"
+	"github.com/1Password/connect-sdk-go/onepassword"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+var oneOfUUIDName = []string{"uuid", "name"}
+
+func dataSourceOnepasswordVault() *schema.Resource {
+	return &schema.Resource{
+		Description: "Use this data source to get details of a vault by either its name or uuid.",
+		Read:        dataSourceOnepasswordVaultRead,
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Description: "The ID of this resource.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"uuid": {
+				Description:  "The UUID of the vault to retrieve.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ExactlyOneOf: oneOfUUIDName,
+			},
+			"name": {
+				Description:  "The name of the vault to retrieve.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ExactlyOneOf: oneOfUUIDName,
+			},
+			"description": {
+				Description: "The description of the vault.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func dataSourceOnepasswordVaultRead(data *schema.ResourceData, meta interface{}) error {
+	client := meta.(connect.Client)
+
+	title := data.Get("name").(string)
+	vaultUUID := data.Get("uuid").(string)
+
+	var vault *onepassword.Vault
+	if vaultUUID != "" {
+		vaultByUUID, err := client.GetVault(vaultUUID)
+		if err != nil {
+			return err
+		}
+		vault = vaultByUUID
+	} else {
+		vaultsByName, err := client.GetVaultsByTitle(title)
+		if err != nil {
+			return err
+		}
+		if len(vaultsByName) == 0 {
+			return fmt.Errorf("no vault found with name '%s'", title)
+		} else if len(vaultsByName) > 1 {
+			return fmt.Errorf("multiple vaults found with name '%s'", title)
+		}
+		vault = &vaultsByName[0]
+	}
+
+	data.SetId(vaultTerraformID(vault))
+	data.Set("uuid", vault.ID)
+	data.Set("name", vault.Name)
+	data.Set("description", vault.Description)
+
+	return nil
+}
+
+func vaultTerraformID(vault *onepassword.Vault) string {
+	return fmt.Sprintf("vaults/%s", vault.ID)
+}

--- a/onepassword/data_source_onepassword_vault_test.go
+++ b/onepassword/data_source_onepassword_vault_test.go
@@ -1,0 +1,118 @@
+package onepassword
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/1Password/connect-sdk-go/onepassword"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestDataSourceOnePasswordVaultRead(t *testing.T) {
+	expectedVault := onepassword.Vault{
+		ID:          "vault-uuid",
+		Name:        "Name of the vault",
+		Description: "This vault will be retrieve",
+	}
+
+	var connectErr = errors.New("some request error")
+
+	cases := map[string]struct {
+		input              map[string]string
+		getVaultRes        onepassword.Vault
+		getVaultErr        error
+		getVaultByTitleRes []onepassword.Vault
+		getVaultByTitleErr error
+		expected           onepassword.Vault
+		expectedErr        error
+	}{
+		"by name": {
+			input: map[string]string{
+				"name": expectedVault.Name,
+			},
+			getVaultByTitleRes: []onepassword.Vault{
+				expectedVault,
+			},
+			expected: expectedVault,
+		},
+		"by error": {
+			input: map[string]string{
+				"name": expectedVault.Name,
+			},
+			getVaultByTitleErr: connectErr,
+			expectedErr:        connectErr,
+		},
+		"not_found_by_name": {
+			input: map[string]string{
+				"name": expectedVault.Name,
+			},
+			getVaultByTitleRes: []onepassword.Vault{},
+			expectedErr:        fmt.Errorf("no vault found with name '%s'", expectedVault.Name),
+		},
+		"multiple_found_by_name": {
+			input: map[string]string{
+				"name": expectedVault.Name,
+			},
+			getVaultByTitleRes: []onepassword.Vault{
+				expectedVault,
+				expectedVault,
+			},
+			expectedErr: fmt.Errorf("multiple vaults found with name '%s'", expectedVault.Name),
+		},
+		"by uuid": {
+			input: map[string]string{
+				"uuid": expectedVault.ID,
+			},
+			getVaultRes: expectedVault,
+			expected:    expectedVault,
+		},
+		"by uuid error": {
+			input: map[string]string{
+				"uuid": expectedVault.ID,
+			},
+			getVaultErr: connectErr,
+			expectedErr: connectErr,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			client := &testClient{
+				GetVaultsByTitleFunc: func(title string) ([]onepassword.Vault, error) {
+					return tc.getVaultByTitleRes, tc.getVaultByTitleErr
+				},
+				GetVaultFunc: func(uuid string) (*onepassword.Vault, error) {
+					return &tc.getVaultRes, tc.getVaultErr
+				},
+			}
+			dataSourceData := schema.TestResourceDataRaw(t, dataSourceOnepasswordVault().Schema, nil)
+
+			for key, value := range tc.input {
+				dataSourceData.Set(key, value)
+			}
+
+			err := dataSourceOnepasswordVaultRead(dataSourceData, client)
+
+			if tc.expectedErr != nil {
+				if err == nil || err.Error() != tc.expectedErr.Error() {
+					t.Errorf("Unexpected error occured. Expected %v, got %v", tc.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Got unexpected error: %s", err)
+				}
+				assertResourceValue(t, dataSourceData, "uuid", tc.expected.ID)
+				assertResourceValue(t, dataSourceData, "name", tc.expected.Name)
+				assertResourceValue(t, dataSourceData, "description", tc.expected.Description)
+			}
+		})
+	}
+}
+
+func assertResourceValue(t *testing.T, data *schema.ResourceData, key, expectedValue string) {
+	value := data.Get(key)
+	if value != expectedValue {
+		t.Errorf("unexpected value for field %s. Expected %s, got %s", key, expectedValue, value)
+	}
+}

--- a/onepassword/mock_connect_test.go
+++ b/onepassword/mock_connect_test.go
@@ -7,6 +7,7 @@ import (
 
 type testClient struct {
 	GetVaultsFunc        func() ([]onepassword.Vault, error)
+	GetVaultFunc         func(vaultUUID string) (*onepassword.Vault, error)
 	GetVaultsByTitleFunc func(title string) ([]onepassword.Vault, error)
 	GetItemFunc          func(uuid string, vaultUUID string) (*onepassword.Item, error)
 	GetItemsFunc         func(vaultUUID string) ([]onepassword.Item, error)
@@ -22,6 +23,10 @@ var _ connect.Client = (*testClient)(nil)
 // Do is the mock client's `Do` func
 func (m *testClient) GetVaults() ([]onepassword.Vault, error) {
 	return m.GetVaultsFunc()
+}
+
+func (m *testClient) GetVault(vaultUUID string) (*onepassword.Vault, error) {
+	return m.GetVaultFunc(vaultUUID)
 }
 
 func (m *testClient) GetVaultsByTitle(title string) ([]onepassword.Vault, error) {

--- a/onepassword/mock_connect_test.go
+++ b/onepassword/mock_connect_test.go
@@ -1,6 +1,9 @@
 package onepassword
 
-import "github.com/1Password/connect-sdk-go/onepassword"
+import (
+	"github.com/1Password/connect-sdk-go/connect"
+	"github.com/1Password/connect-sdk-go/onepassword"
+)
 
 type testClient struct {
 	GetVaultsFunc        func() ([]onepassword.Vault, error)
@@ -14,51 +17,41 @@ type testClient struct {
 	DeleteItemFunc       func(item *onepassword.Item, vaultUUID string) error
 }
 
-var (
-	DoGetVaultsFunc        func() ([]onepassword.Vault, error)
-	DoGetVaultsByTitleFunc func(title string) ([]onepassword.Vault, error)
-	DoGetItemFunc          func(uuid string, vaultUUID string) (*onepassword.Item, error)
-	DoGetItemsByTitleFunc  func(title string, vaultUUID string) ([]onepassword.Item, error)
-	DoGetItemByTitleFunc   func(title string, vaultUUID string) (*onepassword.Item, error)
-	DoCreateItemFunc       func(item *onepassword.Item, vaultUUID string) (*onepassword.Item, error)
-	DoDeleteItemFunc       func(item *onepassword.Item, vaultUUID string) error
-	DoGetItemsFunc         func(vaultUUID string) ([]onepassword.Item, error)
-	DoUpdateItemFunc       func(item *onepassword.Item, vaultUUID string) (*onepassword.Item, error)
-)
+var _ connect.Client = (*testClient)(nil)
 
 // Do is the mock client's `Do` func
 func (m *testClient) GetVaults() ([]onepassword.Vault, error) {
-	return DoGetVaultsFunc()
+	return m.GetVaultsFunc()
 }
 
 func (m *testClient) GetVaultsByTitle(title string) ([]onepassword.Vault, error) {
-	return DoGetVaultsByTitleFunc(title)
+	return m.GetVaultsByTitleFunc(title)
 }
 
 func (m *testClient) GetItem(uuid string, vaultUUID string) (*onepassword.Item, error) {
-	return DoGetItemFunc(uuid, vaultUUID)
+	return m.GetItemFunc(uuid, vaultUUID)
 }
 
 func (m *testClient) GetItems(vaultUUID string) ([]onepassword.Item, error) {
-	return DoGetItemsFunc(vaultUUID)
+	return m.GetItemsFunc(vaultUUID)
 }
 
 func (m *testClient) GetItemsByTitle(title string, vaultUUID string) ([]onepassword.Item, error) {
-	return DoGetItemsByTitleFunc(title, vaultUUID)
+	return m.GetItemsByTitleFunc(title, vaultUUID)
 }
 
 func (m *testClient) GetItemByTitle(title string, vaultUUID string) (*onepassword.Item, error) {
-	return DoGetItemByTitleFunc(title, vaultUUID)
+	return m.GetItemByTitleFunc(title, vaultUUID)
 }
 
 func (m *testClient) CreateItem(item *onepassword.Item, vaultUUID string) (*onepassword.Item, error) {
-	return DoCreateItemFunc(item, vaultUUID)
+	return m.CreateItemFunc(item, vaultUUID)
 }
 
 func (m *testClient) DeleteItem(item *onepassword.Item, vaultUUID string) error {
-	return DoDeleteItemFunc(item, vaultUUID)
+	return m.DeleteItemFunc(item, vaultUUID)
 }
 
 func (m *testClient) UpdateItem(item *onepassword.Item, vaultUUID string) (*onepassword.Item, error) {
-	return DoUpdateItemFunc(item, vaultUUID)
+	return m.UpdateItemFunc(item, vaultUUID)
 }

--- a/onepassword/provider.go
+++ b/onepassword/provider.go
@@ -46,7 +46,8 @@ func Provider() *schema.Provider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"onepassword_item": dataSourceOnepasswordItem(),
+			"onepassword_vault": dataSourceOnepasswordVault(),
+			"onepassword_item":  dataSourceOnepasswordItem(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"onepassword_item": resourceOnepasswordItem(),

--- a/onepassword/provider_test.go
+++ b/onepassword/provider_test.go
@@ -60,6 +60,7 @@ func TestProvider_HasResources(t *testing.T) {
 func TestProvider_HasDataSources(t *testing.T) {
 	expectedDataSources := []string{
 		"onepassword_item",
+		"onepassword_vault",
 	}
 
 	dataSources := Provider().DataSourcesMap

--- a/onepassword/resource_onepassword_item_test.go
+++ b/onepassword/resource_onepassword_item_test.go
@@ -105,11 +105,12 @@ func TestAddSectionsToItem(t *testing.T) {
 }
 
 func testCRUDForItem(t *testing.T, itemToCreate *schema.ResourceData) {
-	meta := &testClient{}
-	DoGetItemFunc = getItem
-	DoCreateItemFunc = createItem
-	DoDeleteItemFunc = deleteItem
-	DoUpdateItemFunc = updateItem
+	meta := &testClient{
+		GetItemFunc:    getItem,
+		CreateItemFunc: createItem,
+		DeleteItemFunc: deleteItem,
+		UpdateItemFunc: updateItem,
+	}
 
 	// Creating an Item
 	err := resourceOnepasswordItemCreate(itemToCreate, meta)

--- a/vendor/github.com/1Password/connect-sdk-go/LICENSE
+++ b/vendor/github.com/1Password/connect-sdk-go/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 1Password
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/1Password/connect-sdk-go/connect/version.go
+++ b/vendor/github.com/1Password/connect-sdk-go/connect/version.go
@@ -2,4 +2,4 @@ package connect
 
 // SDKVersion is the latest Semantic Version of the library
 // Do not rename this variable without changing the regex in the Makefile
-const SDKVersion = "1.0.1"
+const SDKVersion = "1.1.0"

--- a/vendor/github.com/1Password/connect-sdk-go/onepassword/items.go
+++ b/vendor/github.com/1Password/connect-sdk-go/onepassword/items.go
@@ -28,6 +28,7 @@ const (
 	Document             ItemCategory = "DOCUMENT"
 	EmailAccount         ItemCategory = "EMAIL_ACCOUNT"
 	SocialSecurityNumber ItemCategory = "SOCIAL_SECURITY_NUMBER"
+	ApiCredential        ItemCategory = "API_CREDENTIAL"
 	Custom               ItemCategory = "CUSTOM"
 )
 
@@ -39,7 +40,7 @@ func (ic *ItemCategory) UnmarshalJSON(b []byte) error {
 	switch category {
 	case Login, Password, Server, Database, CreditCard, Membership, Passport, SoftwareLicense,
 		OutdoorLicense, SecureNote, WirelessRouter, BankAccount, DriverLicense, Identity, RewardProgram,
-		Document, EmailAccount, SocialSecurityNumber:
+		Document, EmailAccount, SocialSecurityNumber, ApiCredential:
 		*ic = category
 	default:
 		*ic = Custom

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -8,7 +8,7 @@ cloud.google.com/go/internal/trace
 cloud.google.com/go/internal/version
 # cloud.google.com/go/storage v1.10.0
 cloud.google.com/go/storage
-# github.com/1Password/connect-sdk-go v1.0.1
+# github.com/1Password/connect-sdk-go v1.0.2-0.20210528135252-bfc6d04506d6
 ## explicit
 github.com/1Password/connect-sdk-go/connect
 github.com/1Password/connect-sdk-go/onepassword

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -8,7 +8,7 @@ cloud.google.com/go/internal/trace
 cloud.google.com/go/internal/version
 # cloud.google.com/go/storage v1.10.0
 cloud.google.com/go/storage
-# github.com/1Password/connect-sdk-go v1.0.2-0.20210528135252-bfc6d04506d6
+# github.com/1Password/connect-sdk-go v1.1.0
 ## explicit
 github.com/1Password/connect-sdk-go/connect
 github.com/1Password/connect-sdk-go/onepassword


### PR DESCRIPTION
This adds a data source for vaults that can be used to look up a vault by its UUID or name. For example:

```hcl
data "onepassword_vault" "my_vault" {
    name = "My Vault"
}

output "my_vault_id" {
    value = data.onepassword_vault.my_vault.uuid
}
```
or
```hcl
data "onepassword_vault" "my_vault" {
    uuid = "ghacthv5i7gextkqv45g7algw5"
}

output "my_vault_name" {
    value = data.onepassword_vault.my_vault.name
}
```