### PR TITLE
Clean up readme to focus on usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+## Building
+
+To build the 1Password Connect Terraform provider run the following
+
+```sh
+$ go build .
+```
+
+This will create the `terraform-provider-onepassword` binary
+
+## Testing the Provider
+
+To run the go tests and check test coverage run the following
+
+```sh
+$ go test -v ./... -cover
+```
+
+## Generating Documentation
+
+Documentation is generated for the provider using the [terraform documentation plugin](https://github.com/hashicorp/terraform-plugin-docs). This plugin uses the schema `Description` field in conjunction with the contents of the `/templates` and `/examples` folders to generate the `/docs` content.
+
+To regenerate the `/docs` markdown run
+
+```sh
+$ go generate
+```
+
+## Installing Locally
+
+To install the binary it must be copied to the appropriate terraform plugin directory. You may need to create the appropriate directories. For more information [see these Terraform 0.13 plugin docs](https://www.hashicorp.com/blog/automatic-installation-of-third-party-providers-with-terraform-0-13)
+
+The current version of the provider is considered to be 0.2 and `darwin_amd64` should match your machines operating system and architecture in the format `$OS_$ARCH`. For example macOS is `darwin_amd64` and linux is `linux_amd64`.
+
+```sh
+$ mkdir -p ~/.terraform.d/plugins/github.com/1Password/onepassword/0.2/darwin_amd64/
+$ cp ./terraform-provider-onepassword ~/.terraform.d/plugins/github.com/1Password/onepassword/0.2/darwin_amd64/terraform-provider-onepassword
+```
+
+## Using plugin locally
+
+In your Terraform configuration you will need to specify the op plugin with
+
+```tf
+terraform {
+  required_providers {
+    onepassword = {
+      source   = "github.com/1Password/onepassword"
+      version = "~> 1.0.0"
+    }
+  }
+}
+
+provider "onepassword" {
+  url     = "http://<1Password Connect API Hostname>"
+}
+```
+
+After copying a newly built version of the provider to the plugins directory you will have to run `terraform init` again. If you forget to do this terraform will error out and tell you to do so.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,7 @@
+# Contributing to 1Password
+
+Thank you so much for contributing to 1Password. We appreciate your time and help. Here are some guidelines to help you get started.
+
 ## Building
 
 To build the 1Password Connect Terraform provider run the following

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Use the 1Password Connect Terraform Provider to reference, create, or update ite
 
 ## Usage
 
-Detailed documentation for using this provider can be found [here](https://registry.terraform.io/providers/1Password/onepassword/latest/docs).
+Detailed documentation for using this provider can be found on the [Terraform Registry docs](https://registry.terraform.io/providers/1Password/onepassword/latest/docs).
 
 ```tf
 terraform {

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Use the 1Password Connect Terraform Provider to reference, create, or update ite
 
 ## Usage
 
+Detailed documentation for using this provider can be found [here](https://registry.terraform.io/providers/1Password/onepassword/latest/docs).
+
 ```tf
 terraform {
   required_providers {

--- a/README.md
+++ b/README.md
@@ -37,62 +37,6 @@ resource "onepassword_item" "demo_login" {
 
 See the [examples](./examples/) directory for a full example.
 
-## Building
+## Contributing
 
-To build the 1Password Connect Terraform provider run the following
-
-```sh
-$ go build .
-```
-
-This will create the `terraform-provider-onepassword` binary
-
-## Testing the Provider
-
-To run the go tests and check test coverage run the following
-
-```sh
-$ go test -v ./... -cover
-```
-
-## Generating Documentation
-
-Documentation is generated for the provider using the [terraform documentation plugin](https://github.com/hashicorp/terraform-plugin-docs). This plugin uses the schema `Description` field in conjunction with the contents of the `/templates` and `/examples` folders to generate the `/docs` content.
-
-To regenerate the `/docs` markdown run
-
-```sh
-$ go generate
-```
-
-## Installing Locally
-
-To install the binary it must be copied to the appropriate terraform plugin directory. You may need to create the appropriate directories. For more information [see these Terraform 0.13 plugin docs](https://www.hashicorp.com/blog/automatic-installation-of-third-party-providers-with-terraform-0-13)
-
-The current version of the provider is considered to be 0.2 and `darwin_amd64` should match your machines operating system and architecture in the format `$OS_$ARCH`. For example macOS is `darwin_amd64` and linux is `linux_amd64`.
-
-```sh
-$ mkdir -p ~/.terraform.d/plugins/github.com/1Password/onepassword/0.2/darwin_amd64/
-$ cp ./terraform-provider-onepassword ~/.terraform.d/plugins/github.com/1Password/onepassword/0.2/darwin_amd64/terraform-provider-onepassword
-```
-
-## Using plugin locally
-
-In your Terraform configuration you will need to specify the op plugin with
-
-```tf
-terraform {
-  required_providers {
-    onepassword = {
-      source   = "github.com/1Password/onepassword"
-      version = "~> 1.0.0"
-    }
-  }
-}
-
-provider "onepassword" {
-  url     = "http://<1Password Connect API Hostname>"
-}
-```
-
-After copying a newly built version of the provider to the plugins directory you will have to run `terraform init` again. If you forget to do this terraform will error out and tell you to do so.
+Detailed documentation for contributing to the 1Password Terraform provider can be found [here](https://github.com/1Password/terraform-provider-onepassword/blob/main/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ See the [examples](./examples/) directory for a full example.
 
 ## Contributing
 
-Detailed documentation for contributing to the 1Password Terraform provider can be found [here](https://github.com/1Password/terraform-provider-onepassword/blob/main/CONTRIBUTING.md).
+Detailed documentation for contributing to the 1Password Terraform provider can be found [here](./CONTRIBUTING.md).


### PR DESCRIPTION
This should make it easier for users who just want to use the provider to find the right information. Previously, the instructions for local installation may have let them to believe that was necessary for usage, while it is only necessary to locally develop the provider.

Users who want to contribute to the provider, can now find detailed instructions in a separate doc.