### PR TITLE
Use a more recent version of Go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/1Password/terraform-provider-onepassword
 
-go 1.15
+go 1.16
 
 require (
 	github.com/1Password/connect-sdk-go v1.1.0


### PR DESCRIPTION
Needed to use on Apple silicon (darwin_arm64 isn't built on Go < 1.16).

See https://github.com/1Password/terraform-provider-onepassword/runs/2773180408?check_suite_focus=true#step:5:33