### PR TITLE
Fix docs regarding the vault data source

### DIFF
--- a/docs/data-sources/item.md
+++ b/docs/data-sources/item.md
@@ -26,7 +26,7 @@ data "onepassword_item" "example" {
 
 ### Optional
 
-- **id** (String, Optional) The ID of this resource.
+- **id** (String, Optional) The Terraform resource identifier for this item in the format `vaults/<vault_id>/items/<item_id>`.
 - **tags** (List of String, Optional) An array of strings of the tags assigned to the item.
 - **title** (String, Optional) The title of the item.
 - **uuid** (String, Optional) The UUID of the item. Item identifiers are unique within a specific vault.

--- a/docs/data-sources/vault.md
+++ b/docs/data-sources/vault.md
@@ -21,6 +21,4 @@ Use this data source to get details of a vault by either its name or uuid.
 ### Read-only
 
 - **description** (String, Read-only) The description of the vault.
-- **id** (String, Read-only) The ID of this resource.
-
-
+- **uuid** (String, Read-only) The UUID of the vault. 

--- a/docs/data-sources/vault.md
+++ b/docs/data-sources/vault.md
@@ -21,4 +21,5 @@ Use this data source to get details of a vault by either its name or uuid.
 ### Read-only
 
 - **description** (String, Read-only) The description of the vault.
+- **id** (String, Read-only) The Terraform resource identifier for this item in the format `vaults/<vault_id>`
 - **uuid** (String, Read-only) The UUID of the vault. 


### PR DESCRIPTION
Two small adjustments in the docs:
 - the vault data source has the `uuid` read-only parameter
 - the `id` of the item data source has been clarified