### PR TITLE
Fix providing token through prompt

### DIFF
--- a/onepassword/provider.go
+++ b/onepassword/provider.go
@@ -36,7 +36,8 @@ func Provider() *schema.Provider {
 			"url": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "The HTTP(S) URL where your 1Password Connect API can be found",
+				DefaultFunc: schema.EnvDefaultFunc("OP_CONNECT_HOST", nil),
+				Description: "The HTTP(S) URL where your 1Password Connect API can be found. Can also be sourced from OP_CONNECT_HOST.",
 			},
 			"token": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
As reported in https://github.com/1Password/terraform-provider-onepassword/issues/46, Terraform can throw the following error when only the `url` attibrute is set in the provider configuration block:

```
The attribute "url" is required, but no definition was found.
```

This happens when the `token` attribute is provided through the prompt instead of by setting the `OP_CONNECT_TOKEN` environment variable and is caused by Terraform's weird handling of multiple required attributes for a provider.

I suggest to address this by turning the `url` field in an optional field for Terraform and verifying that it is actually set in the `ConfigureFunc`. In practice this means that `token` and `url` are still both required, but that only `token` will be prompted for. It also resolves Terraform's weird behaviour of forgetting the `url` when set.