### PR TITLE
Fix (T)OTP field type

### DIFF
--- a/docs/resources/item.md
+++ b/docs/resources/item.md
@@ -110,7 +110,7 @@ Optional:
 - **id** (String, Optional) A unique identifier for the field.
 - **password_recipe** (Block List, Max: 1) Password for this item. (see [below for nested schema](#nestedblock--section--field--password_recipe))
 - **purpose** (String, Optional) Purpose indicates this is a special field: a username, password, or notes field. One of ["USERNAME" "PASSWORD" "NOTES"]
-- **type** (String, Optional) The type of value stored in the field. One of ["STRING" "EMAIL" "CONCEALED" "URL" "TOTP" "DATE" "MONTH_YEAR" "MENU"]
+- **type** (String, Optional) The type of value stored in the field. One of ["STRING" "EMAIL" "CONCEALED" "URL" "OTP" "DATE" "MONTH_YEAR" "MENU"]
 - **value** (String, Optional) The value of the field.
 
 <a id="nestedblock--section--field--password_recipe"></a>

--- a/onepassword/resource_onepassword_item.go
+++ b/onepassword/resource_onepassword_item.go
@@ -53,7 +53,7 @@ const (
 var categories = []string{"login", "password", "database"}
 var dbTypes = []string{"db2", "filemaker", "msaccess", "mssql", "mysql", "oracle", "postgresql", "sqlite", "other"}
 var fieldPurposes = []string{"USERNAME", "PASSWORD", "NOTES"}
-var fieldTypes = []string{"STRING", "EMAIL", "CONCEALED", "URL", "TOTP", "DATE", "MONTH_YEAR", "MENU"}
+var fieldTypes = []string{"STRING", "EMAIL", "CONCEALED", "URL", "OTP", "DATE", "MONTH_YEAR", "MENU"}
 
 func resourceOnepasswordItem() *schema.Resource {
 	passwordRecipe := &schema.Schema{


### PR DESCRIPTION
As I've reported in #54, the correct `field.type` is `"OTP"` rather than `"TOTP"`. In this PR I've made relevant changes in hope that it would save you some time editing files :)

I've tested this using a local provider override in my infrastructure against 1Password Connect 1.5.0 server and was successfully able to create a bunch of items with OTP fields, so I can vouch this change actually works.

I was not able to update existing items, changing existing `field`'s `type` from `"CONCEALED"` to `"OTP"` - `terraform apply` had the correct plan and succeeded but nothing had actually changed. However, I believe that's a separate issue that probably lies with the Connect servers rather than this Terraform provider (although it can be argued that provider could be told that such change requires re-creating of a resource). Destroying those items and re-creating them anew worked.

Hope this could get merged and a new version of provider released, so we would be able to use OTP fields soon!

Thanks!