### PR TITLE
Add fields to each items default section

### DIFF
--- a/docs/data-sources/item.md
+++ b/docs/data-sources/item.md
@@ -32,8 +32,9 @@ data "onepassword_item" "example" {
 
 ### Read-only
 
-- **category** (String, Read-only) The category of the item. One of ["login" "password" "database"]
+- **category** (String, Read-only) The category of the item. One of ["login" "password" "database" "secure_note"]
 - **database** (String, Read-only) (Only applies to the database category) The name of the database.
+- **field** (Block List) A list of custom fields in an item (see [below for nested schema](#nestedblock--field))
 - **hostname** (String, Read-only) (Only applies to the database category) The address where the database can be found
 - **id** (String, Read-only) The Terraform resource identifier for this item in the format `vaults/<vault_id>/items/<item_id>`
 - **password** (String, Read-only) Password for this item.
@@ -43,6 +44,18 @@ data "onepassword_item" "example" {
 - **type** (String, Read-only) (Only applies to the database category) The type of database. One of ["db2" "filemaker" "msaccess" "mssql" "mysql" "oracle" "postgresql" "sqlite" "other"]
 - **url** (String, Read-only) The primary URL for the item.
 - **username** (String, Read-only) Username for this item.
+
+<a id="nestedblock--field"></a>
+### Nested Schema for `field`
+
+Read-only:
+
+- **id** (String, Read-only) A unique identifier for the field.
+- **label** (String, Read-only) The label for the field.
+- **purpose** (String, Read-only) Purpose indicates this is a special field: a username, password, or notes field. One of ["USERNAME" "PASSWORD" "NOTES"]
+- **type** (String, Read-only) The type of value stored in the field. One of ["STRING" "EMAIL" "CONCEALED" "URL" "OTP" "DATE" "MONTH_YEAR" "MENU"]
+- **value** (String, Read-only) The value of the field.
+
 
 <a id="nestedatt--section"></a>
 ### Nested Schema for `section`

--- a/docs/resources/item.md
+++ b/docs/resources/item.md
@@ -54,9 +54,11 @@ resource "onepassword_item" "demo_db" {
 
 ### Optional
 
-- **category** (String, Optional) The category of the item. One of ["login" "password" "database"]
+- **category** (String, Optional) The category of the item. One of ["login" "password" "database" "secure_note"]
 - **database** (String, Optional) (Only applies to the database category) The name of the database.
+- **field** (Block List) A list of custom fields in an item (see [below for nested schema](#nestedblock--field))
 - **hostname** (String, Optional) (Only applies to the database category) The address where the database can be found
+- **note_value** (String, Optional) Secure Note value.
 - **password** (String, Optional) Password for this item.
 - **password_recipe** (Block List, Max: 1) Password for this item. (see [below for nested schema](#nestedblock--password_recipe))
 - **port** (String, Optional) (Only applies to the database category) The port the database is listening on.
@@ -71,6 +73,35 @@ resource "onepassword_item" "demo_db" {
 
 - **id** (String, Read-only) The Terraform resource identifier for this item in the format `vaults/<vault_id>/items/<item_id>`.
 - **uuid** (String, Read-only) The UUID of the item. Item identifiers are unique within a specific vault.
+
+<a id="nestedblock--field"></a>
+### Nested Schema for `field`
+
+Required:
+
+- **label** (String, Required) The label for the field.
+
+Optional:
+
+- **password_recipe** (Block List, Max: 1) Password for this item. (see [below for nested schema](#nestedblock--field--password_recipe))
+- **type** (String, Optional) The type of value stored in the field. One of ["STRING" "EMAIL" "CONCEALED" "URL" "OTP" "DATE" "MONTH_YEAR" "MENU"]
+- **value** (String, Optional) The value of the field.
+
+Read-only:
+
+- **id** (String, Read-only) A unique identifier for the field.
+
+<a id="nestedblock--field--password_recipe"></a>
+### Nested Schema for `field.password_recipe`
+
+Optional:
+
+- **digits** (Boolean, Optional) Use digits [0-9] when generating the password.
+- **length** (Number, Optional) The length of the password to be generated.
+- **letters** (Boolean, Optional) Use letters [a-zA-Z] when generating the password.
+- **symbols** (Boolean, Optional) Use symbols [!@.-_*] when generating the password.
+
+
 
 <a id="nestedblock--password_recipe"></a>
 ### Nested Schema for `password_recipe`
@@ -107,11 +138,13 @@ Required:
 
 Optional:
 
-- **id** (String, Optional) A unique identifier for the field.
 - **password_recipe** (Block List, Max: 1) Password for this item. (see [below for nested schema](#nestedblock--section--field--password_recipe))
-- **purpose** (String, Optional) Purpose indicates this is a special field: a username, password, or notes field. One of ["USERNAME" "PASSWORD" "NOTES"]
 - **type** (String, Optional) The type of value stored in the field. One of ["STRING" "EMAIL" "CONCEALED" "URL" "OTP" "DATE" "MONTH_YEAR" "MENU"]
 - **value** (String, Optional) The value of the field.
+
+Read-only:
+
+- **id** (String, Read-only) A unique identifier for the field.
 
 <a id="nestedblock--section--field--password_recipe"></a>
 ### Nested Schema for `section.field.password_recipe`

--- a/onepassword/resource_onepassword_item_test.go
+++ b/onepassword/resource_onepassword_item_test.go
@@ -26,9 +26,10 @@ var schemaKeys = []string{
 
 func TestResourceItemToDataDataToTitem(t *testing.T) {
 	resources := map[string]*schema.ResourceData{
-		"login":    generateResourceLoginItem(t),
-		"database": generateResourceDatabaseItem(t),
-		"password": generateResourcePasswordItem(t),
+		"login":       generateResourceLoginItem(t),
+		"database":    generateResourceDatabaseItem(t),
+		"password":    generateResourcePasswordItem(t),
+		"secure_note": generateResourceSecureNoteItem(t),
 	}
 	for name, resource := range resources {
 		t.Run(name, func(t *testing.T) {
@@ -104,6 +105,26 @@ func TestAddSectionsToItem(t *testing.T) {
 	testCRUDForItem(t, item)
 }
 
+func TestAddFieldsToItem(t *testing.T) {
+	item := generateResourceLoginItem(t)
+
+	fields := []interface{}{
+		map[string]interface{}{
+			"label": "secret value",
+			"type":  "CONCEALED",
+			"value": "secret",
+		},
+		map[string]interface{}{
+			"label": "user",
+			"value": "root",
+		},
+	}
+
+	item.Set("field", fields)
+
+	testCRUDForItem(t, item)
+}
+
 func testCRUDForItem(t *testing.T, itemToCreate *schema.ResourceData) {
 	meta := &testClient{
 		GetItemFunc:    getItem,
@@ -133,7 +154,7 @@ func testCRUDForItem(t *testing.T, itemToCreate *schema.ResourceData) {
 	itemToCreate.Set("password", "new_password")
 	err = resourceOnepasswordItemUpdate(itemToCreate, meta)
 	if err != nil {
-		t.Errorf("Unexpected error occured when deleting item")
+		t.Errorf("Unexpected error occured when updating item")
 	}
 	err = resourceOnepasswordItemRead(itemRead, meta)
 	if err != nil {
@@ -219,6 +240,12 @@ func generateResourcePasswordItem(t *testing.T) *schema.ResourceData {
 	resourceData := generateBaseItem(t)
 	resourceData.Set("category", "password")
 	resourceData.Set("password", "test_password")
+	return resourceData
+}
+
+func generateResourceSecureNoteItem(t *testing.T) *schema.ResourceData {
+	resourceData := generateBaseItem(t)
+	resourceData.Set("category", "secure_note")
 	return resourceData
 }
 


### PR DESCRIPTION
Resolves: #17 

_Description:_
There is currently no ability to add custom fields outside of a section with the 1Password Terraform provider.

_Solution:_
A list of fields can now be defined outside of a section. Applying this is similar to how we currently implement fields inside a section.

It's important to note that in order to make this happen some other updates had to take place:
- A `secure_note` category is added because there was no way to add fields without a password (also referenced in #66).
- Include `note_value` in the resource as it was previously set in the data source.
- Delete `purpose` value from from the fields as it can cause a collision with the `note_value` argument when `NOTES` is set as the purpose.
- Fix bug where it wasn't capturing deleted fields from an existing item and therefore wasn't trying to recreate the deleted fields when running `terraform apply`.