### PR TITLE
Removing deprecated use of --rm-dist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,8 @@ jobs:
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: latest
-          args: release --rm-dist
+          version: 1.19.1
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/1Password/terraform-provider-onepassword
 
-go 1.20
+go 1.19
 
 require (
 	github.com/1Password/connect-sdk-go v1.5.1


### PR DESCRIPTION
`--rm-dist` has been deprecated for the goreleaser action. It has now been replaced with `--clean`

Goreleaser version has also been updated to a stable version number rather than always pulling the latest. This helps ensure that breaking changes aren't accidentally introduced to our pipeline.

There may be an issue with the releaser working with the latest version of go, so this will also allow for us to test the pipeline with a downgraded go version (to 1.19).