### PR TITLE
Updating the `CONTRIBUTING.md` file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ go generate
 
 To install the binary it must be copied to the appropriate Terraform plugin directory (note that you may need to create these directories first). You can refer to the [Terraform 0.13 plugin docs](https://www.hashicorp.com/blog/automatic-installation-of-third-party-providers-with-terraform-0-13) for more information.
 
-The current version of the provider is considered to be 0.2 and `darwin_amd64` should match your machines operating system and architecture in the format `$OS_$ARCH`. For example, macOS is `darwin_amd64` and Linux is `linux_amd64`.
+The current version of the provider is 1.2.0. Your machine's operating system and architecture should be specified in the `$OS_$ARCH` format. For example, macOS is `darwin_amd64` and Linux is `linux_amd64`.
 
 ```sh
 mkdir -p ~/.terraform.d/plugins/github.com/1Password/onepassword/0.2/darwin_amd64/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
 # Contributing
 
-Thank you so much for contributing to 1Password. We appreciate your time and help. Here are some guidelines to help you get started.
+Thanks for your interest in contributing to the 1Password Connect Terraform Provider project! 🙌 We appreciate your time and effort. Here are some guidelines to help you get started.
 
 ## Building
 
-To build the 1Password Connect Terraform provider run the following:
+Run the following command to build the 1Password Connect Terraform Provider:
 
 ```sh
 go build .
@@ -14,7 +14,7 @@ This will create the `terraform-provider-onepassword` binary.
 
 ## Testing the Provider
 
-To run the go tests and check test coverage run the following:
+To run the Go tests and check test coverage run the following:
 
 ```sh
 go test -v ./... -cover
@@ -22,19 +22,19 @@ go test -v ./... -cover
 
 ## Generating Documentation
 
-Documentation is generated for the provider using the [terraform documentation plugin](https://github.com/hashicorp/terraform-plugin-docs). This plugin uses the schema `Description` field in conjunction with the contents of the `/templates` and `/examples` folders to generate the `/docs` content.
+Documentation is generated for the provider using [terraform-plugin-docs](https://github.com/hashicorp/terraform-plugin-docs). This plugin uses the schema `Description` field in conjunction with the contents of the `/templates` and `/examples` folders to generate the `/docs` content.
 
-To regenerate the `/docs` markdown run:
+To regenerate the `/docs` Markdown run:
 
 ```sh
 go generate
 ```
 
-## Installing Locally
+## Installing plugin locally
 
-To install the binary it must be copied to the appropriate terraform plugin directory. You may need to create the appropriate directories. For more information [see these Terraform 0.13 plugin docs](https://www.hashicorp.com/blog/automatic-installation-of-third-party-providers-with-terraform-0-13)
+To install the binary it must be copied to the appropriate Terraform plugin directory (note that you may need to create these directories first). You can refer to the [Terraform 0.13 plugin docs](https://www.hashicorp.com/blog/automatic-installation-of-third-party-providers-with-terraform-0-13) for more information.
 
-The current version of the provider is considered to be 0.2 and `darwin_amd64` should match your machines operating system and architecture in the format `$OS_$ARCH`. For example macOS is `darwin_amd64` and linux is `linux_amd64`.
+The current version of the provider is considered to be 0.2 and `darwin_amd64` should match your machines operating system and architecture in the format `$OS_$ARCH`. For example, macOS is `darwin_amd64` and Linux is `linux_amd64`.
 
 ```sh
 mkdir -p ~/.terraform.d/plugins/github.com/1Password/onepassword/0.2/darwin_amd64/
@@ -60,4 +60,4 @@ provider "onepassword" {
 }
 ```
 
-After copying a newly built version of the provider to the plugins directory you will have to run `terraform init` again. If you forget to do this terraform will error out and tell you to do so.
+After copying a newly-built version of the provider to the plugins directory you will have to run `terraform init` again. If you forget to do this then Terraform will error out and tell you to do so.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thank you so much for contributing to 1Password. We appreciate your time and hel
 To build the 1Password Connect Terraform provider run the following:
 
 ```sh
-$ go build .
+go build .
 ```
 
 This will create the `terraform-provider-onepassword` binary.
@@ -17,7 +17,7 @@ This will create the `terraform-provider-onepassword` binary.
 To run the go tests and check test coverage run the following:
 
 ```sh
-$ go test -v ./... -cover
+go test -v ./... -cover
 ```
 
 ## Generating Documentation
@@ -27,7 +27,7 @@ Documentation is generated for the provider using the [terraform documentation p
 To regenerate the `/docs` markdown run:
 
 ```sh
-$ go generate
+go generate
 ```
 
 ## Installing Locally
@@ -37,8 +37,8 @@ To install the binary it must be copied to the appropriate terraform plugin dire
 The current version of the provider is considered to be 0.2 and `darwin_amd64` should match your machines operating system and architecture in the format `$OS_$ARCH`. For example macOS is `darwin_amd64` and linux is `linux_amd64`.
 
 ```sh
-$ mkdir -p ~/.terraform.d/plugins/github.com/1Password/onepassword/0.2/darwin_amd64/
-$ cp ./terraform-provider-onepassword ~/.terraform.d/plugins/github.com/1Password/onepassword/0.2/darwin_amd64/terraform-provider-onepassword
+mkdir -p ~/.terraform.d/plugins/github.com/1Password/onepassword/0.2/darwin_amd64/
+cp ./terraform-provider-onepassword ~/.terraform.d/plugins/github.com/1Password/onepassword/0.2/darwin_amd64/terraform-provider-onepassword
 ```
 
 ## Using plugin locally

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,20 +43,20 @@ cp ./terraform-provider-onepassword ~/.terraform.d/plugins/github.com/1Password/
 
 ## Using plugin locally
 
-In your Terraform configuration you will need to specify the op plugin with:
+In your Terraform configuration you will need to specify the `op` plugin with:
 
 ```tf
 terraform {
   required_providers {
     onepassword = {
-      source   = "github.com/1Password/onepassword"
+      source  = "1Password/onepassword"
       version = "~> 1.2.0"
     }
   }
 }
 
 provider "onepassword" {
-  url     = "http://<1Password Connect API Hostname>"
+  url = "http://<1Password Connect API Hostname>"
 }
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,14 +32,10 @@ go generate
 
 ## Installing plugin locally
 
-To install the binary it must be copied to the appropriate Terraform plugin directory (note that you may need to create these directories first). You can refer to the [Terraform 0.13 plugin docs](https://www.hashicorp.com/blog/automatic-installation-of-third-party-providers-with-terraform-0-13) for more information.
+Refer to the following sections of the Terraform's "Custom Framework Providers" tutorial to install this plugin locally:
 
-The current version of the provider is 1.2.0. Your machine's operating system and architecture should be specified in the `$OS_$ARCH` format. For example, macOS is `darwin_amd64` and Linux is `linux_amd64`.
-
-```sh
-mkdir -p ~/.terraform.d/plugins/github.com/1Password/onepassword/0.2/darwin_amd64/
-cp ./terraform-provider-onepassword ~/.terraform.d/plugins/github.com/1Password/onepassword/0.2/darwin_amd64/terraform-provider-onepassword
-```
+- [Prepare Terraform for local provider install](https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-provider#prepare-terraform-for-local-provider-install)
+- [Locally install provider and verify with Terraform](https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-provider#locally-install-provider-and-verify-with-terraform)
 
 ## Using plugin locally
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,20 +14,10 @@ This will create the `terraform-provider-onepassword` binary.
 
 ## Testing the Provider
 
-To run the Go tests and check test coverage run the following:
+To run the Go tests and check test coverage run the following command:
 
 ```sh
 go test -v ./... -cover
-```
-
-## Generating Documentation
-
-Documentation is generated for the provider using [terraform-plugin-docs](https://github.com/hashicorp/terraform-plugin-docs). This plugin uses the schema `Description` field in conjunction with the contents of the `/templates` and `/examples` folders to generate the `/docs` content.
-
-To regenerate the `/docs` Markdown run:
-
-```sh
-go generate
 ```
 
 ## Installing plugin locally
@@ -57,3 +47,13 @@ provider "onepassword" {
 ```
 
 After copying a newly-built version of the provider to the plugins directory you will have to run `terraform init` again. If you forget to do this then Terraform will error out and tell you to do so.
+
+## Generating Documentation
+
+Documentation is generated for the provider using [terraform-plugin-docs](https://github.com/hashicorp/terraform-plugin-docs). This plugin uses the schema `Description` field in conjunction with the contents of the `/templates` and `/examples` folders to generate the `/docs` content.
+
+To regenerate the `/docs` Markdown run:
+
+```sh
+go generate
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ terraform {
   required_providers {
     onepassword = {
       source   = "github.com/1Password/onepassword"
-      version = "~> 1.0.0"
+      version = "~> 1.2.0"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     onepassword = {
       source = "1Password/onepassword"
-      version = "~> 1.1.2"
+      version = "~> 1.2.0"
     }
   }
 }

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     onepassword = {
       source  = "1Password/onepassword"
-      version = "~> 1.0.1"
+      version = "~> 1.2.0"
     }
   }
 }


### PR DESCRIPTION
This PR makes some updates to our `CONTRIBUTING.md` guidelines and also modernizes the content.

## Summary

- The commit messages are all pretty descriptive, so please refer to them for details of the changes.
- Regarding the f404955394f75c8b0787b77dd55ce24e0d549bcc commit: I updated every instance of `required_providers.onepassword.version` that I could find to `1.2.0` to align with our [latest release](https://github.com/1Password/terraform-provider-onepassword/releases).
- I left some pre-review notes/questions for reviewers; the two most important ones are regarding Terraform v0.13 and the CPU architecture examples that we list.