### PR TITLE
Fix item creation with sections

### DIFF
--- a/onepassword/resource_onepassword_item.go
+++ b/onepassword/resource_onepassword_item.go
@@ -546,19 +546,17 @@ func dataToItem(data *schema.ResourceData) (*onepassword.Item, error) {
 		if !ok {
 			return nil, fmt.Errorf("Unable to parse section: %v", sections[i])
 		}
-		sid, err := uuid.GenerateUUID()
-		if err != nil {
-			return nil, fmt.Errorf("Unable to generate a section id: %w", err)
-		}
 
-		if section["id"].(string) != "" {
-			sid = section["id"].(string)
-		} else {
+		if section["id"].(string) == "" {
+			sid, err := uuid.GenerateUUID()
+			if err != nil {
+				return nil, fmt.Errorf("Unable to generate a section id: %w", err)
+			}
 			section["id"] = sid
 		}
 
 		s := &onepassword.ItemSection{
-			ID:    sid,
+			ID:    section["id"].(string),
 			Label: section["label"].(string),
 		}
 		item.Sections = append(item.Sections, s)
@@ -570,11 +568,19 @@ func dataToItem(data *schema.ResourceData) (*onepassword.Item, error) {
 				return nil, fmt.Errorf("Unable to parse section field: %v", sectionFields[j])
 			}
 
+			if field["id"].(string) == "" {
+				fid, err := uuid.GenerateUUID()
+				if err != nil {
+					return nil, fmt.Errorf("Unable to generate a field id: %w", err)
+				}
+				field["id"] = fid
+			}
+
 			f := &onepassword.ItemField{
 				Section: s,
 				ID:      field["id"].(string),
 				Type:    onepassword.ItemFieldType(field["type"].(string)),
-				Purpose: onepassword.ItemFieldPurpose(field["type"].(string)),
+				Purpose: onepassword.ItemFieldPurpose(field["purpose"].(string)),
 				Label:   field["label"].(string),
 				Value:   field["value"].(string),
 			}

--- a/onepassword/resource_onepassword_item.go
+++ b/onepassword/resource_onepassword_item.go
@@ -546,19 +546,17 @@ func dataToItem(data *schema.ResourceData) (*onepassword.Item, error) {
 		if !ok {
 			return nil, fmt.Errorf("Unable to parse section: %v", sections[i])
 		}
-		sid, err := uuid.GenerateUUID()
-		if err != nil {
-			return nil, fmt.Errorf("Unable to generate a section id: %w", err)
-		}
 
-		if section["id"].(string) != "" {
-			sid = section["id"].(string)
-		} else {
+		if section["id"].(string) == "" {
+			sid, err := uuid.GenerateUUID()
+			if err != nil {
+				return nil, fmt.Errorf("Unable to generate a section id: %w", err)
+			}
 			section["id"] = sid
 		}
 
 		s := &onepassword.ItemSection{
-			ID:    sid,
+			ID:    section["id"].(string),
 			Label: section["label"].(string),
 		}
 		item.Sections = append(item.Sections, s)

--- a/onepassword/resource_onepassword_item.go
+++ b/onepassword/resource_onepassword_item.go
@@ -547,16 +547,19 @@ func dataToItem(data *schema.ResourceData) (*onepassword.Item, error) {
 			return nil, fmt.Errorf("Unable to parse section: %v", sections[i])
 		}
 
-		if section["id"].(string) == "" {
-			sid, err := uuid.GenerateUUID()
-			if err != nil {
-				return nil, fmt.Errorf("Unable to generate a section id: %w", err)
-			}
+		sid, err := uuid.GenerateUUID()
+		if err != nil {
+			return nil, fmt.Errorf("Unable to generate a section id: %w", err)
+		}
+
+		if section["id"].(string) != "" {
+			sid = section["id"].(string)
+		} else {
 			section["id"] = sid
 		}
 
 		s := &onepassword.ItemSection{
-			ID:    section["id"].(string),
+			ID:    sid,
 			Label: section["label"].(string),
 		}
 		item.Sections = append(item.Sections, s)
@@ -566,14 +569,6 @@ func dataToItem(data *schema.ResourceData) (*onepassword.Item, error) {
 			field, ok := sectionFields[j].(map[string]interface{})
 			if !ok {
 				return nil, fmt.Errorf("Unable to parse section field: %v", sectionFields[j])
-			}
-
-			if field["id"].(string) == "" {
-				fid, err := uuid.GenerateUUID()
-				if err != nil {
-					return nil, fmt.Errorf("Unable to generate a field id: %w", err)
-				}
-				field["id"] = fid
 			}
 
 			f := &onepassword.ItemField{

--- a/onepassword/resource_onepassword_item.go
+++ b/onepassword/resource_onepassword_item.go
@@ -546,7 +546,6 @@ func dataToItem(data *schema.ResourceData) (*onepassword.Item, error) {
 		if !ok {
 			return nil, fmt.Errorf("Unable to parse section: %v", sections[i])
 		}
-
 		sid, err := uuid.GenerateUUID()
 		if err != nil {
 			return nil, fmt.Errorf("Unable to generate a section id: %w", err)


### PR DESCRIPTION
## Overview

Currently, creating items with sections through the Terraform provider does not work.

It seems like the `Purpose` field for item section fields is being assigned improperly. If a `type` is specified when creating a resource, this `type` value is being assigned to the section field's `Purpose`. This causes an error, since the expected values for `Type` and `Purpose` differ. For more details on the expected values for each, refer to the documentation here: https://developer.1password.com/docs/connect/connect-api-reference/#item-field-object.

I also made a small change to the logic for generating a section ID, to make it cleaner.

## Type of change

Bug fix

## Related Issue(s)

- Resolves: #96 

## How To Test

1. Pull the branch locally: `git pull && git checkout wpark/96-fix-sections`
2. Configure a provider override in your `~/.terraformrc` file, so that you use a local build of the provider rather than the published version. Refer to the documentation here for more details: https://developer.hashicorp.com/terraform/cli/config/config-file#development-overrides-for-provider-developers. Your `.terraformrc` file should look like this:

```
provider_installation {

  dev_overrides {
      "1Password/onepassword" = "<path to terraform-provider-onepassword repo root directory>"
  }

  # For all other providers, install them directly from their origin provider
  # registries as normal. If you omit this, Terraform will _only_ use
  # the dev_overrides block, and so no other providers will be available.
  direct {}
}
```

3. Navigate to the root of the `terraform-provider-onepassword` repo and generate a local build: `go build`
4. Create an item resource with sections using `terraform apply`. Follow the instructions [here](https://github.com/1Password/terraform-provider-onepassword/tree/main/examples) - the example `main.tf` contains a `demo_sections` resource that you can use to test this

 - [ ] In the vault that your connect server has access rights to, the item should have been successfully created with sections, and the item should match the resource outlined in `main.tf`. If you used the example provided in the repo, the item should look like this:
 
<img width="564" alt="image" src="https://github.com/1Password/terraform-provider-onepassword/assets/53918631/12066b94-6c78-4c79-830e-fc510f6f2bd7">

5. Check the generated item within Terraform state by running `terraform state show`, e.g. `terraform state show onepassword_item.demo_sections`

- [ ] The outputted resource should match the resource outlined in `main.tf`, and the `id` for all sections and fields should be populated