### PR TITLE
Add support to run provider with debuggers

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"github.com/1Password/terraform-provider-onepassword/onepassword"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 )
@@ -16,7 +17,14 @@ import (
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
 
 func main() {
+	var debug bool
+
+	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
 	plugin.Serve(&plugin.ServeOpts{
 		ProviderFunc: onepassword.Provider,
+		ProviderAddr: "1Password/onepassword",
+		Debug:        debug,
 	})
 }


### PR DESCRIPTION
## Overview

This PR adds support for debugging tools like Delve and Goland, which should improve the debugging experience for developers contributing to the provider.

## Type of change

Enhancement

## Related Issue(s)

- Resolves: #102 

## How To Test

1. Pull the branch locally: `git pull && git checkout wpark/102-debugging-support`
2. Configure a provider override in your `~/.terraformrc file`, so that you use a local build of the provider rather than the published version. Refer to the documentation here for more details: https://developer.hashicorp.com/terraform/cli/config/config-file#development-overrides-for-provider-developers. Your `.terraformrc` file should look like this:

```
provider_installation {

  dev_overrides {
      "1Password/onepassword" = "<path to terraform-provider-onepassword repo root directory>"
  }

  # For all other providers, install them directly from their origin provider
  # registries as normal. If you omit this, Terraform will _only_ use
  # the dev_overrides block, and so no other providers will be available.
  direct {}
}
```

3.  Install Delve on your system: https://github.com/go-delve/delve/tree/master/Documentation/installation
4. With either Delve or another debugging tool (e.g Goland), run a debugging session. Follow the instructions [here](https://opencredo.com/blogs/running-a-terraform-provider-with-a-debugger/), referring to the `Compiling in debug mode` section onward
6. Navigate to the `examples` directory in your terminal. Set the `TF_REATTACH_PROVIDERS` variable: `export TF_REATTACH_PROVIDERS=<outputted value from debugging session>` 
7. Set breakpoints in your code
8. Test creating and destroying item resources. Follow the instructions [here](https://github.com/1Password/terraform-provider-onepassword/tree/main/examples)

- [ ] The breakpoints should be hit during the debugging session as expected