### PR TITLE
Moves op version check from provider initialization to before executing op commands

### DIFF
--- a/onepassword/cli/op.go
+++ b/onepassword/cli/op.go
@@ -107,16 +107,16 @@ func (op *OP) GetItemByTitle(ctx context.Context, title string, vaultUuid string
 }
 
 func (op *OP) CreateItem(ctx context.Context, item *onepassword.Item, vaultUuid string) (*onepassword.Item, error) {
+	versionErr := op.checkCliVersion(ctx)
+	if versionErr != nil {
+		return nil, versionErr
+	}
 	return op.withRetry(func() (*onepassword.Item, error) {
 		return op.create(ctx, item, vaultUuid)
 	})
 }
 
 func (op *OP) create(ctx context.Context, item *onepassword.Item, vaultUuid string) (*onepassword.Item, error) {
-	versionErr := op.checkCliVersion(ctx)
-	if versionErr != nil {
-		return nil, versionErr
-	}
 	if item.Vault.ID != "" && item.Vault.ID != vaultUuid {
 		return nil, errors.New("item payload contains vault id that does not match vault uuid")
 	}
@@ -147,16 +147,16 @@ func (op *OP) create(ctx context.Context, item *onepassword.Item, vaultUuid stri
 }
 
 func (op *OP) UpdateItem(ctx context.Context, item *onepassword.Item, vaultUuid string) (*onepassword.Item, error) {
+	versionErr := op.checkCliVersion(ctx)
+	if versionErr != nil {
+		return nil, versionErr
+	}
 	return op.withRetry(func() (*onepassword.Item, error) {
 		return op.update(ctx, item, vaultUuid)
 	})
 }
 
 func (op *OP) update(ctx context.Context, item *onepassword.Item, vaultUuid string) (*onepassword.Item, error) {
-	versionErr := op.checkCliVersion(ctx)
-	if versionErr != nil {
-		return nil, versionErr
-	}
 	if item.Vault.ID != "" && item.Vault.ID != vaultUuid {
 		return nil, errors.New("item payload contains vault id that does not match vault uuid")
 	}
@@ -176,6 +176,10 @@ func (op *OP) update(ctx context.Context, item *onepassword.Item, vaultUuid stri
 }
 
 func (op *OP) DeleteItem(ctx context.Context, item *onepassword.Item, vaultUuid string) error {
+	versionErr := op.checkCliVersion(ctx)
+	if versionErr != nil {
+		return versionErr
+	}
 	_, err := op.withRetry(func() (*onepassword.Item, error) {
 		return op.delete(ctx, item, vaultUuid)
 	})
@@ -186,10 +190,6 @@ func (op *OP) DeleteItem(ctx context.Context, item *onepassword.Item, vaultUuid 
 }
 
 func (op *OP) delete(ctx context.Context, item *onepassword.Item, vaultUuid string) (*onepassword.Item, error) {
-	versionErr := op.checkCliVersion(ctx)
-	if versionErr != nil {
-		return nil, versionErr
-	}
 	if item.Vault.ID != "" && item.Vault.ID != vaultUuid {
 		return nil, errors.New("item payload contains vault id that does not match vault uuid")
 	}

--- a/onepassword/cli/op.go
+++ b/onepassword/cli/op.go
@@ -14,6 +14,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
+const (
+	minimumOpCliVersion = "2.23.0" // introduction of stdin json support for `op item update`
+)
+
 type OP struct {
 	binaryPath          string
 	serviceAccountToken string
@@ -41,7 +45,22 @@ func (op *OP) GetVersion(ctx context.Context) (*semver.Version, error) {
 	return version, nil
 }
 
+func (op *OP) checkCliVersion(ctx context.Context) error {
+	cliVersion, err := op.GetVersion(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get version of op CLI: %w", err)
+	}
+	if cliVersion.LessThan(semver.MustParse(minimumOpCliVersion)) {
+		return fmt.Errorf("current 1Password CLI version is \"%s\". Please upgrade to at least \"%s\"", cliVersion, minimumOpCliVersion)
+	}
+	return nil
+}
+
 func (op *OP) GetVault(ctx context.Context, uuid string) (*onepassword.Vault, error) {
+	versionErr := op.checkCliVersion(ctx)
+	if versionErr != nil {
+		return nil, versionErr
+	}
 	var res *onepassword.Vault
 	err := op.execJson(ctx, &res, nil, p("vault"), p("get"), p(uuid))
 	if err != nil {
@@ -51,6 +70,10 @@ func (op *OP) GetVault(ctx context.Context, uuid string) (*onepassword.Vault, er
 }
 
 func (op *OP) GetVaultsByTitle(ctx context.Context, title string) ([]onepassword.Vault, error) {
+	versionErr := op.checkCliVersion(ctx)
+	if versionErr != nil {
+		return nil, versionErr
+	}
 	var allVaults []onepassword.Vault
 	err := op.execJson(ctx, &allVaults, nil, p("vault"), p("list"))
 	if err != nil {
@@ -67,6 +90,10 @@ func (op *OP) GetVaultsByTitle(ctx context.Context, title string) ([]onepassword
 }
 
 func (op *OP) GetItem(ctx context.Context, itemUuid, vaultUuid string) (*onepassword.Item, error) {
+	versionErr := op.checkCliVersion(ctx)
+	if versionErr != nil {
+		return nil, versionErr
+	}
 	var res *onepassword.Item
 	err := op.execJson(ctx, &res, nil, p("item"), p("get"), p(itemUuid), f("vault", vaultUuid))
 	if err != nil {
@@ -86,6 +113,10 @@ func (op *OP) CreateItem(ctx context.Context, item *onepassword.Item, vaultUuid 
 }
 
 func (op *OP) create(ctx context.Context, item *onepassword.Item, vaultUuid string) (*onepassword.Item, error) {
+	versionErr := op.checkCliVersion(ctx)
+	if versionErr != nil {
+		return nil, versionErr
+	}
 	if item.Vault.ID != "" && item.Vault.ID != vaultUuid {
 		return nil, errors.New("item payload contains vault id that does not match vault uuid")
 	}
@@ -122,6 +153,10 @@ func (op *OP) UpdateItem(ctx context.Context, item *onepassword.Item, vaultUuid 
 }
 
 func (op *OP) update(ctx context.Context, item *onepassword.Item, vaultUuid string) (*onepassword.Item, error) {
+	versionErr := op.checkCliVersion(ctx)
+	if versionErr != nil {
+		return nil, versionErr
+	}
 	if item.Vault.ID != "" && item.Vault.ID != vaultUuid {
 		return nil, errors.New("item payload contains vault id that does not match vault uuid")
 	}
@@ -151,6 +186,10 @@ func (op *OP) DeleteItem(ctx context.Context, item *onepassword.Item, vaultUuid 
 }
 
 func (op *OP) delete(ctx context.Context, item *onepassword.Item, vaultUuid string) (*onepassword.Item, error) {
+	versionErr := op.checkCliVersion(ctx)
+	if versionErr != nil {
+		return nil, versionErr
+	}
 	if item.Vault.ID != "" && item.Vault.ID != vaultUuid {
 		return nil, errors.New("item payload contains vault id that does not match vault uuid")
 	}

--- a/onepassword/provider.go
+++ b/onepassword/provider.go
@@ -9,14 +9,12 @@ import (
 	"github.com/1Password/terraform-provider-onepassword/onepassword/cli"
 	"github.com/1Password/terraform-provider-onepassword/onepassword/connectctx"
 	"github.com/1Password/terraform-provider-onepassword/version"
-	"github.com/Masterminds/semver/v3"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 const (
 	terraformProviderUserAgent = "terraform-provider-connect/%s"
-	minimumOpCliVersion        = "2.23.0" // introduction of stdin json support for `op item update`
 )
 
 func init() {
@@ -122,14 +120,6 @@ func initializeCLI(ctx context.Context, serviceAccountToken, account, opCliPath 
 	// override OP to use service account token
 	if serviceAccountToken != "" {
 		op = cli.New(serviceAccountToken, opCliPath, "")
-	}
-
-	cliVersion, err := op.GetVersion(ctx)
-	if err != nil {
-		return nil, diag.FromErr(fmt.Errorf("failed to get version of op CLI: %w", err))
-	}
-	if cliVersion.LessThan(semver.MustParse(minimumOpCliVersion)) {
-		return nil, diag.Errorf("Current 1Password CLI version is \"%s\". Please upgrade to at least \"%s\".", cliVersion, minimumOpCliVersion)
 	}
 
 	return op, nil


### PR DESCRIPTION
Attempts to fix #116.

The op cli may not be available when the provider is initialised. e.g. when the cli is installed via a provisioner in a terraform cloud instance.

The version of the op cli is now checked before each op command is run. 