### PR TITLE
fix: fix op cli always generating passwords

### DIFF
--- a/onepassword/cli/op.go
+++ b/onepassword/cli/op.go
@@ -100,12 +100,9 @@ func (op *OP) create(ctx context.Context, item *onepassword.Item, vaultUuid stri
 	args := []opArg{p("item"), p("create"), p("-")}
 	// 'op item create' command doesn't support generating passwords when using templates
 	// therefore need to use --generate-password flag to set it
-	if pf := passwordField(item); pf != nil {
-		recipeStr := "letters,digits,32"
-		if pf.Recipe != nil {
-			recipeStr = passwordRecipeToString(pf.Recipe)
-		}
-		args = append(args, f("generate-password", recipeStr))
+	recipe := passwordRecipe(item)
+	if recipe != "" {
+		args = append(args, f("generate-password", recipe))
 	}
 
 	err = op.execJson(ctx, &res, payload, args...)

--- a/onepassword/cli/utils.go
+++ b/onepassword/cli/utils.go
@@ -60,6 +60,16 @@ func passwordField(item *onepassword.Item) *onepassword.ItemField {
 	return nil
 }
 
+func passwordRecipe(item *onepassword.Item) string {
+	str := ""
+	if pf := passwordField(item); pf != nil {
+		if pf.Recipe != nil {
+			return passwordRecipeToString(pf.Recipe)
+		}
+	}
+	return str
+}
+
 func passwordRecipeToString(recipe *onepassword.GeneratorRecipe) string {
 	str := ""
 	if recipe != nil {

--- a/onepassword/cli/utils.go
+++ b/onepassword/cli/utils.go
@@ -61,13 +61,10 @@ func passwordField(item *onepassword.Item) *onepassword.ItemField {
 }
 
 func passwordRecipe(item *onepassword.Item) string {
-	str := ""
 	if pf := passwordField(item); pf != nil {
-		if pf.Recipe != nil {
-			return passwordRecipeToString(pf.Recipe)
-		}
+		return passwordRecipeToString(pf.Recipe)
 	}
-	return str
+	return ""
 }
 
 func passwordRecipeToString(recipe *onepassword.GeneratorRecipe) string {

--- a/onepassword/cli/utils_test.go
+++ b/onepassword/cli/utils_test.go
@@ -50,6 +50,55 @@ func TestPasswordField(t *testing.T) {
 	}
 }
 
+func TestPasswordRecipeExtraction(t *testing.T) {
+	tests := map[string]struct {
+		item           *onepassword.Item
+		expectedString string
+	}{
+		"should return empty string if item has no fields": {
+			item:           &onepassword.Item{},
+			expectedString: "",
+		},
+		"should return empty string if no password field": {
+			item: &onepassword.Item{
+				Fields: []*onepassword.ItemField{
+					{Purpose: onepassword.FieldPurposeNotes},
+				},
+			},
+			expectedString: "",
+		},
+		"should return empty string if no password recipe": {
+			item: &onepassword.Item{
+				Fields: []*onepassword.ItemField{
+					{ID: "username", Purpose: onepassword.FieldPurposeUsername},
+					{ID: "password", Purpose: onepassword.FieldPurposePassword},
+				},
+			},
+			expectedString: "",
+		},
+		"should return recipe string": {
+			item: &onepassword.Item{
+				Fields: []*onepassword.ItemField{
+					{ID: "username", Purpose: onepassword.FieldPurposeUsername},
+					{ID: "password", Purpose: onepassword.FieldPurposePassword, Recipe: &onepassword.GeneratorRecipe{
+						Length: 30,
+					}},
+				},
+			},
+			expectedString: "30",
+		},
+	}
+
+	for description, test := range tests {
+		t.Run(description, func(t *testing.T) {
+			actualString := passwordRecipe(test.item)
+			if actualString != test.expectedString {
+				t.Errorf("Unexpected password recipe string. Expected \"%s\", but got \"%s\"", test.expectedString, actualString)
+			}
+		})
+	}
+}
+
 func TestPasswordRecipeToString(t *testing.T) {
 	tests := map[string]struct {
 		recipe         *onepassword.GeneratorRecipe


### PR DESCRIPTION
When invoking the op cli, if the onepassword item had no password recipe, generate-password would always be appended to the cli args and any password value would be overwritten by a generated password.

Note I am very new to Go so please point me in the right direction if needed :)

As part of this fix I have extracted the logic which constructs the generate-password cli arg into a function in utils, and implemented a test around it.

Fixes #128 