### PR TITLE
Pass proper user agent info to the CLI

### DIFF
--- a/onepassword/cli/op.go
+++ b/onepassword/cli/op.go
@@ -220,9 +220,9 @@ func (op *OP) execRaw(ctx context.Context, stdin []byte, args ...opArg) ([]byte,
 	cmd := exec.CommandContext(ctx, op.binaryPath, cmdArgs...)
 	cmd.Env = append(cmd.Environ(),
 		"OP_FORMAT=json",
-		"OP_INTEGRATION_NAME=terraform-provider-connect",
-		"OP_INTEGRATION_ID=GO",
 		//"OP_INTEGRATION_BUILDNUMBER="+version.ProviderVersion, // causes bad request errors from CLI
+		"OP_INTEGRATION_NAME=terraform-provider",
+		"OP_INTEGRATION_ID=TFP",
 	)
 	if op.serviceAccountToken != "" {
 		cmd.Env = append(cmd.Env, "OP_SERVICE_ACCOUNT_TOKEN="+op.serviceAccountToken)

--- a/onepassword/cli/op.go
+++ b/onepassword/cli/op.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/1Password/connect-sdk-go/onepassword"
+	"github.com/1Password/terraform-provider-onepassword/version"
 	"github.com/Masterminds/semver/v3"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -220,9 +221,9 @@ func (op *OP) execRaw(ctx context.Context, stdin []byte, args ...opArg) ([]byte,
 	cmd := exec.CommandContext(ctx, op.binaryPath, cmdArgs...)
 	cmd.Env = append(cmd.Environ(),
 		"OP_FORMAT=json",
-		//"OP_INTEGRATION_BUILDNUMBER="+version.ProviderVersion, // causes bad request errors from CLI
 		"OP_INTEGRATION_NAME=terraform-provider",
 		"OP_INTEGRATION_ID=TFP",
+		"OP_INTEGRATION_BUILDNUMBER="+makeBuildVersion(version.ProviderVersion),
 	)
 	if op.serviceAccountToken != "" {
 		cmd.Env = append(cmd.Env, "OP_SERVICE_ACCOUNT_TOKEN="+op.serviceAccountToken)

--- a/onepassword/cli/utils.go
+++ b/onepassword/cli/utils.go
@@ -97,3 +97,19 @@ func waitBeforeRetry(retryAttempts int) {
 	wait := time.Duration(retryTimeMilliseconds) * time.Millisecond
 	time.Sleep(wait)
 }
+
+func makeBuildVersion(version string) string {
+	parts := strings.Split(strings.ReplaceAll(version, "-beta", ""), ".")
+	buildVersion := parts[0]
+	for i := 1; i < len(parts); i++ {
+		if len(parts[i]) == 1 {
+			buildVersion += "0" + parts[i]
+		} else {
+			buildVersion += parts[i]
+		}
+	}
+	if len(parts) != 3 {
+		return buildVersion
+	}
+	return buildVersion + "01"
+}

--- a/onepassword/cli/utils_test.go
+++ b/onepassword/cli/utils_test.go
@@ -148,3 +148,29 @@ func TestPasswordRecipeToString(t *testing.T) {
 		})
 	}
 }
+
+func TestMakeBuildVersion(t *testing.T) {
+	tests := map[string]struct {
+		input    string
+		expected string
+	}{
+		"test stable version": {
+			input:    "1.5.6",
+			expected: "1050601",
+		},
+		"test beta version": {
+			input:    "0.1.0-beta.01",
+			expected: "0010001",
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			actualBuildVersion := makeBuildVersion(tc.input)
+			if tc.expected != actualBuildVersion {
+				t.Errorf("Unexpected version build number. Expected \"%s\", but got \"%s\"", tc.expected, actualBuildVersion)
+			}
+		})
+	}
+}

--- a/version/version.go
+++ b/version/version.go
@@ -2,5 +2,5 @@ package version
 
 var (
 	// ProviderVersion is set during release.
-	ProviderVersion = "dev"
+	ProviderVersion = "1.4.2"
 )


### PR DESCRIPTION
This PR brings the user-agent info passed to the CLI up-to-date.

Resolves #124.

Specifically, the user agent info is as follows:

| Environment variable | Value |
|:--------------------:|:------:|
| `OP_INTEGRATION_NAME` | `terraform-provider` |
| `OP_INTEGRATION_ID` |  `TFP` |
| `OP_INTEGRATION_BUILDNUMBER` | build version of the provider e.g. `1040201` |

**Notes:** 
- I've changed the ID compared to the issue from `TP` to `TFP` to match the 3-letter pattern that we use for the ID in other integrations.
- The `makeBuildVersion` function is identical to the one we've done for the [`kubernetes-secrets-injector`](https://github.com/1Password/kubernetes-secrets-injector/blob/main/pkg/utils/build_version.go).