### PR TITLE
Add support for document data source

### DIFF
--- a/docs/data-sources/item.md
+++ b/docs/data-sources/item.md
@@ -34,8 +34,9 @@ data "onepassword_item" "example" {
 
 ### Read-Only
 
-- `category` (String) The category of the item. One of ["login" "password" "database"]
+- `category` (String) The category of the item. One of ["login" "password" "database" "document"]
 - `database` (String) (Only applies to the database category) The name of the database.
+- `file` (List of Object) A list of files in the section. (see [below for nested schema](#nestedatt--file))
 - `hostname` (String) (Only applies to the database category) The address where the database can be found
 - `id` (String) The Terraform resource identifier for this item in the format `vaults/<vault_id>/items/<item_id>`
 - `password` (String, Sensitive) Password for this item.
@@ -45,6 +46,17 @@ data "onepassword_item" "example" {
 - `type` (String) (Only applies to the database category) The type of database. One of ["db2" "filemaker" "msaccess" "mssql" "mysql" "oracle" "postgresql" "sqlite" "other"]
 - `url` (String) The primary URL for the item.
 - `username` (String) Username for this item.
+
+<a id="nestedatt--file"></a>
+### Nested Schema for `file`
+
+Read-Only:
+
+- `content` (String)
+- `content_base64` (String)
+- `id` (String)
+- `name` (String)
+
 
 <a id="nestedatt--section"></a>
 ### Nested Schema for `section`

--- a/docs/resources/item.md
+++ b/docs/resources/item.md
@@ -66,7 +66,7 @@ resource "onepassword_item" "demo_db" {
 
 ### Optional
 
-- `category` (String) The category of the item. One of ["login" "password" "database"]
+- `category` (String) The category of the item. One of ["login" "password" "database" "document"]
 - `database` (String) (Only applies to the database category) The name of the database.
 - `hostname` (String) (Only applies to the database category) The address where the database can be found
 - `password` (String, Sensitive) Password for this item.

--- a/onepassword/cli/op.go
+++ b/onepassword/cli/op.go
@@ -107,6 +107,19 @@ func (op *OP) GetItemByTitle(ctx context.Context, title string, vaultUuid string
 	return op.GetItem(ctx, title, vaultUuid)
 }
 
+func (op *OP) GetFileContent(ctx context.Context, file *onepassword.File, itemUuid, vaultUuid string) ([]byte, error) {
+	versionErr := op.checkCliVersion(ctx)
+	if versionErr != nil {
+		return nil, versionErr
+	}
+	ref := fmt.Sprintf("op://%s/%s/%s", vaultUuid, itemUuid, file.ID)
+	res, err := op.execRaw(ctx, nil, p("read"), p(ref))
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
 func (op *OP) CreateItem(ctx context.Context, item *onepassword.Item, vaultUuid string) (*onepassword.Item, error) {
 	versionErr := op.checkCliVersion(ctx)
 	if versionErr != nil {

--- a/onepassword/connectctx/wrapper.go
+++ b/onepassword/connectctx/wrapper.go
@@ -39,6 +39,10 @@ func (w *Wrapper) DeleteItem(_ context.Context, item *onepassword.Item, vaultUui
 	return w.client.DeleteItem(item, vaultUuid)
 }
 
+func (w *Wrapper) GetFileContent(_ context.Context, file *onepassword.File, itemUUID, vaultUUID string) ([]byte, error) {
+	return w.client.GetFileContent(file)
+}
+
 func Wrap(client connect.Client) *Wrapper {
 	return &Wrapper{client: client}
 }

--- a/onepassword/data_source_onepassword_item.go
+++ b/onepassword/data_source_onepassword_item.go
@@ -156,7 +156,7 @@ func dataSourceOnepasswordItem() *schema.Resource {
 				},
 			},
 			"file": {
-				Description: sectionFilesDescription,
+				Description: filesListDescription,
 				Type:        schema.TypeList,
 				Computed:    true,
 				MinItems:    0,

--- a/onepassword/data_source_onepassword_item_test.go
+++ b/onepassword/data_source_onepassword_item_test.go
@@ -170,9 +170,6 @@ func compareItemToSource(t *testing.T, dataSourceData *schema.ResourceData, item
 			t.Errorf("Expected file %v to have content %v, got %v", file.Name, string(want), dataSourceData.Get(fmt.Sprintf("file.%d.content", i)))
 		}
 	}
-	if len(item.Files) == 2 {
-		t.Errorf("dafuq")
-	}
 }
 
 func generateDataSource(t *testing.T, item *onepassword.Item) *schema.ResourceData {

--- a/onepassword/mock_client_test.go
+++ b/onepassword/mock_client_test.go
@@ -14,6 +14,7 @@ type testClient struct {
 	CreateItemFunc       func(item *onepassword.Item, vaultUUID string) (*onepassword.Item, error)
 	UpdateItemFunc       func(item *onepassword.Item, vaultUUID string) (*onepassword.Item, error)
 	DeleteItemFunc       func(item *onepassword.Item, vaultUUID string) error
+	GetFileFunc          func(file *onepassword.File, itemUUID, vaultUUID string) ([]byte, error)
 }
 
 var _ Client = (*testClient)(nil)
@@ -44,4 +45,8 @@ func (m *testClient) DeleteItem(_ context.Context, item *onepassword.Item, vault
 
 func (m *testClient) UpdateItem(_ context.Context, item *onepassword.Item, vaultUUID string) (*onepassword.Item, error) {
 	return m.UpdateItemFunc(item, vaultUUID)
+}
+
+func (m *testClient) GetFileContent(_ context.Context, file *onepassword.File, itemUUID, vaultUUID string) ([]byte, error) {
+	return m.GetFileFunc(file, itemUUID, vaultUUID)
 }

--- a/onepassword/provider.go
+++ b/onepassword/provider.go
@@ -134,4 +134,5 @@ type Client interface {
 	CreateItem(ctx context.Context, item *onepassword.Item, vaultUuid string) (*onepassword.Item, error)
 	UpdateItem(ctx context.Context, item *onepassword.Item, vaultUuid string) (*onepassword.Item, error)
 	DeleteItem(ctx context.Context, item *onepassword.Item, vaultUuid string) error
+	GetFileContent(ctx context.Context, file *onepassword.File, itemUUid, vaultUuid string) ([]byte, error)
 }

--- a/onepassword/resource_onepassword_item.go
+++ b/onepassword/resource_onepassword_item.go
@@ -38,12 +38,20 @@ const (
 	sectionLabelDescription  = "The label for the section."
 	sectionFieldsDescription = "A list of custom fields in the section."
 
+	sectionFilesDescription = "A list of files in an item."
+
 	fieldDescription        = "A custom field."
 	fieldIDDescription      = "A unique identifier for the field."
 	fieldLabelDescription   = "The label for the field."
 	fieldPurposeDescription = "Purpose indicates this is a special field: a username, password, or notes field."
 	fieldTypeDescription    = "The type of value stored in the field."
 	fieldValueDescription   = "The value of the field."
+
+	fileDescription              = "A file attached to the item."
+	fileIDDescription            = "A UUID for the file."
+	fileNameDescription          = "The name of the file."
+	fileContentDescription       = "The content of the file."
+	fileContentBase64Description = "The content of the file in base64 encoding. (Use this for binary files.)"
 
 	passwordRecipeDescription  = "The recipe used to generate a new value for a password."
 	passwordElementDescription = "The kinds of characters to include in the password."
@@ -55,7 +63,7 @@ const (
 	enumDescription = "%s One of %q"
 )
 
-var categories = []string{"login", "password", "database"}
+var categories = []string{"login", "password", "database", "document"}
 var dbTypes = []string{"db2", "filemaker", "msaccess", "mssql", "mysql", "oracle", "postgresql", "sqlite", "other"}
 var fieldPurposes = []string{"USERNAME", "PASSWORD", "NOTES"}
 var fieldTypes = []string{"STRING", "EMAIL", "CONCEALED", "URL", "OTP", "DATE", "MONTH_YEAR", "MENU"}

--- a/onepassword/resource_onepassword_item.go
+++ b/onepassword/resource_onepassword_item.go
@@ -38,7 +38,7 @@ const (
 	sectionLabelDescription  = "The label for the section."
 	sectionFieldsDescription = "A list of custom fields in the section."
 
-	sectionFilesDescription = "A list of files in an item."
+	filesListDescription = "A list of files in an item."
 
 	fieldDescription        = "A custom field."
 	fieldIDDescription      = "A unique identifier for the field."

--- a/onepassword/resource_onepassword_item.go
+++ b/onepassword/resource_onepassword_item.go
@@ -141,12 +141,20 @@ func resourceOnepasswordItem() *schema.Resource {
 				ForceNew:    true,
 			},
 			"category": {
-				Description:  fmt.Sprintf(enumDescription, categoryDescription, categories),
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      "login",
-				ValidateFunc: validation.StringInSlice(categories, true),
-				ForceNew:     true,
+				Description: fmt.Sprintf(enumDescription, categoryDescription, categories),
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "login",
+				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+					v := val.(string)
+					f := validation.StringInSlice(categories, true)
+					warns, errs = f(v, key)
+					if v == "document" {
+						errs = append(errs, fmt.Errorf("cannot create document category, connect api do not support it"))
+					}
+					return warns, errs
+				},
+				ForceNew: true,
 			},
 			"title": {
 				Description: itemTitleDescription,


### PR DESCRIPTION
I have have only tested this with unittests and cli, as I do not have a connect.

- Supports multiple files
- Supports text documents and binary documents (provided one uses the `content_base64` version)

Roundtrip test:

```hcl
data "onepassword_item" "foo" {
  vault = var.demo_vault
  uuid  = "..."
}
resource "local_file" "truststore" {
  filename       = "truststore.jks"
  content_base64 = data.onepassword_item.foo.file.2.content_base64
}
```
(where 2 is the third file for that item, added via the UI)

I had to use the `op read` approach rather than `op document get` (unless I am missing an undocumented feature) to be able to handle multiple files.

I have not tried to implement a resource, since as far as I understood connect cannot support it and I don't see a way to distinguish between the two backends.

~~The `document` category is available also for resource, that is slightly incorrect.~~
