### PR TITLE
Feature: File attachments to items

### DIFF
--- a/onepassword/cli/op.go
+++ b/onepassword/cli/op.go
@@ -196,6 +196,21 @@ func (op *OP) delete(ctx context.Context, item *onepassword.Item, vaultUuid stri
 	return nil, op.execJson(ctx, nil, nil, p("item"), p("delete"), p(item.ID), f("vault", vaultUuid))
 }
 
+func (op *OP) GetFileContent(ctx context.Context, file *onepassword.File) ([]byte, error) {
+	versionErr := op.checkCliVersion(ctx)
+	if versionErr != nil {
+		return nil, versionErr
+	}
+
+	path := file.ContentPath
+	path = strings.ReplaceAll(path, "/v1/vaults/", "op://")
+	path = strings.ReplaceAll(path, "/items/", "/")
+	path = strings.ReplaceAll(path, "/files/", "/")
+	path = strings.ReplaceAll(path, "/content", "")
+
+	return op.execRaw(ctx, nil, p("read"), p(path))
+}
+
 func (op *OP) execJson(ctx context.Context, dst any, stdin []byte, args ...opArg) error {
 	result, err := op.execRaw(ctx, stdin, args...)
 	if err != nil {

--- a/onepassword/data_source_onepassword_item.go
+++ b/onepassword/data_source_onepassword_item.go
@@ -96,6 +96,32 @@ func dataSourceOnepasswordItem() *schema.Resource {
 				Optional:    true,
 				Sensitive:   true,
 			},
+			"files": {
+				Description: "Files",
+				Type:        schema.TypeList,
+				Computed:    true,
+				MinItems:    0,
+				Elem: &schema.Resource{
+					Description: "File",
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Description: fieldIDDescription,
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"content": {
+							Description: "File contents",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"name": {
+							Description: "File name",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+					},
+				},
+			},
 			"section": {
 				Description: sectionsDescription,
 				Type:        schema.TypeList,
@@ -222,6 +248,23 @@ func dataSourceOnepasswordItemRead(ctx context.Context, data *schema.ResourceDat
 			}
 		}
 	}
+
+	files := []interface{}{}
+
+	for _, f := range item.Files {
+		bytes, err := client.GetFileContent(ctx, f)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		fileItem := map[string]interface{}{}
+		fileItem["id"] = f.ID
+		fileItem["name"] = f.Name
+		fileItem["content"] = string(bytes)
+
+		files = append(files, fileItem)
+	}
+
+	data.Set("files", files)
 
 	return nil
 }

--- a/onepassword/mock_client_test.go
+++ b/onepassword/mock_client_test.go
@@ -14,6 +14,7 @@ type testClient struct {
 	CreateItemFunc       func(item *onepassword.Item, vaultUUID string) (*onepassword.Item, error)
 	UpdateItemFunc       func(item *onepassword.Item, vaultUUID string) (*onepassword.Item, error)
 	DeleteItemFunc       func(item *onepassword.Item, vaultUUID string) error
+	GetFileContentFunc   func(file *onepassword.File) ([]byte, error)
 }
 
 var _ Client = (*testClient)(nil)
@@ -44,4 +45,8 @@ func (m *testClient) DeleteItem(_ context.Context, item *onepassword.Item, vault
 
 func (m *testClient) UpdateItem(_ context.Context, item *onepassword.Item, vaultUUID string) (*onepassword.Item, error) {
 	return m.UpdateItemFunc(item, vaultUUID)
+}
+
+func (m *testClient) GetFileContent(_ context.Context, file *onepassword.File) ([]byte, error) {
+	return m.GetFileContentFunc(file)
 }

--- a/onepassword/provider.go
+++ b/onepassword/provider.go
@@ -134,4 +134,5 @@ type Client interface {
 	CreateItem(ctx context.Context, item *onepassword.Item, vaultUuid string) (*onepassword.Item, error)
 	UpdateItem(ctx context.Context, item *onepassword.Item, vaultUuid string) (*onepassword.Item, error)
 	DeleteItem(ctx context.Context, item *onepassword.Item, vaultUuid string) error
+	GetFileContent(ctx context.Context, file *onepassword.File) ([]byte, error)
 }


### PR DESCRIPTION
Adds `files` to the item resource, with properties to get the file name and contents.

Uses `op read` to get the file contents after transforming the content path of the file to an `op://` URL.

I tried scanning through the `op` documentation for other ways of doing this, but was unable to find a way to reliably use for instance `op document get`

Fixes 1Password/terraform-provider-onepassword#132