### PR TITLE
Throw error when 1Password client item creation fails

### DIFF
--- a/internal/provider/onepassword_item_resource.go
+++ b/internal/provider/onepassword_item_resource.go
@@ -337,6 +337,7 @@ func (r *OnePasswordItemResource) Create(ctx context.Context, req resource.Creat
 	createdItem, err := r.client.CreateItem(ctx, item, item.Vault.ID)
 	if err != nil {
 		resp.Diagnostics.AddError("1Password Item create error", fmt.Sprintf("Error creating 1Password item, got error %s", err))
+		return
 	}
 
 	resp.Diagnostics.Append(itemToData(ctx, createdItem, &data)...)


### PR DESCRIPTION
## Summary

We add to diagnostics the error returned when the 1Password client fails to create an item. However, we weren't stopping the process, which caused the provider to try to add the "failed" created item in the state which led to a crash of the provider.

Relates: #174

## How to test

1. Checkout this branch:
   ```sh
   git pull && git checkout fix/throw-err-on-item-creation-fail
   ```
2. Build the provider:
   ```sh
   make build
   ```
3. Ensure that [your environment is configured to use the local provider](https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-provider#prepare-terraform-for-local-provider-install). Specifically, your `.terraform.rc` on macOS/Linux or `terraform.rc` on Windows contains this:
   ```
   provider_installation {
     dev_overrides {
         # other overrides
         "1Password/onepassword" = "path/to/terraform-provider-onepassword/dist"
     }
     # For all other providers, install them directly from their origin provider
     # registries as normal. If you omit this, Terraform will _only_ use
     # the dev_overrides block, and so no other providers will be available.
     direct {}
   }
   ```
4. Create a `main.tf` file with this content:
   ```tf
   terraform {
     required_providers {
       onepassword = {
         source = "1Password/onepassword"
         version = "~> 2.0"
       }
     }
   }

   data "onepassword_vault" "vault" {
     name = "demo"
   }

   resource "onepassword_item" "demo_login" {
     vault = data.onepassword_vault.vault.id

     title    = "Demo Terraform Login"
     category = "login"
     username = "test@example.com"
   }
   ```
5. Export the necessary environment variables for the authentication method that you want (Connect, service account or regular user)
6. Run `terraform apply`
   - [ ] The provider **should not** crash
   - [ ] The provider should throw an error like this one:
      ```
      ╷
      │ Error: 1Password Item create error
      │ 
      │   with onepassword_item.demo_login,
      │   on main.tf line 14, in resource "onepassword_item" "demo_login":
      │   14: resource "onepassword_item" "demo_login" {
      │ 
      │ Error creating 1Password item, got error op error: unable to process line 1: "vaults/ba7ntbqcum4tsrcc5ciem5wfsu" isn't a vault in this account. Specify the vault with its ID or name.
      ╵
      ```