### PR TITLE
Add available values for item data source field purpose and type descriptions

### DIFF
--- a/docs/data-sources/item.md
+++ b/docs/data-sources/item.md
@@ -62,6 +62,6 @@ Read-Only:
 
 - `id` (String) A unique identifier for the field.
 - `label` (String) The label for the field.
-- `purpose` (String) Purpose indicates this is a special field: a username, password, or notes field.
-- `type` (String) The type of value stored in the field.
+- `purpose` (String) Purpose indicates this is a special field: a username, password, or notes field. One of ["USERNAME" "PASSWORD" "NOTES"]
+- `type` (String) The type of value stored in the field. One of ["STRING" "CONCEALED" "EMAIL" "URL" "OTP" "DATE" "MONTH_YEAR" "MENU"]
 - `value` (String, Sensitive) The value of the field.

--- a/internal/provider/onepassword_item_data_source.go
+++ b/internal/provider/onepassword_item_data_source.go
@@ -169,11 +169,11 @@ func (d *OnePasswordItemDataSource) Schema(ctx context.Context, req datasource.S
 										Computed:            true,
 									},
 									"purpose": schema.StringAttribute{
-										MarkdownDescription: fieldPurposeDescription,
+										MarkdownDescription: fmt.Sprintf(enumDescription, fieldPurposeDescription, fieldPurposes),
 										Computed:            true,
 									},
 									"type": schema.StringAttribute{
-										MarkdownDescription: fieldTypeDescription,
+										MarkdownDescription: fmt.Sprintf(enumDescription, fieldTypeDescription, fieldTypes),
 										Computed:            true,
 									},
 									"value": schema.StringAttribute{


### PR DESCRIPTION
The descriptions of the field purpose and type for a item data resource also contained the possible values in v1. We're adding them back now since they were missed during the migration.