### PR TITLE
Set password to null if it's unknown

### DIFF
--- a/internal/provider/onepassword_item_resource.go
+++ b/internal/provider/onepassword_item_resource.go
@@ -213,6 +213,7 @@ func (r *OnePasswordItemResource) Schema(ctx context.Context, req resource.Schem
 				Optional:            true,
 				Computed:            true,
 				Sensitive:           true,
+				//Default:             stringdefault.StaticString(""),
 				PlanModifiers: []planmodifier.String{
 					ValueModifier(),
 				},
@@ -601,6 +602,10 @@ func itemToData(ctx context.Context, item *op.Item, data *OnePasswordItemResourc
 				}
 			}
 		}
+	}
+
+	if item.Category == op.SecureNote && data.Password.IsUnknown() {
+		data.Password = types.StringNull()
 	}
 
 	return nil

--- a/internal/provider/onepassword_item_resource_test.go
+++ b/internal/provider/onepassword_item_resource_test.go
@@ -119,6 +119,7 @@ func TestAccItemResourceSecureNote(t *testing.T) {
 					resource.TestCheckResourceAttr("onepassword_item.test-secure-note", "title", expectedItem.Title),
 					resource.TestCheckResourceAttr("onepassword_item.test-secure-note", "category", strings.ToLower(string(expectedItem.Category))),
 					resource.TestCheckResourceAttr("onepassword_item.test-secure-note", "note_value", expectedItem.Fields[0].Value),
+					resource.TestCheckNoResourceAttr("onepassword_item.test-secure-note", "password"),
 				),
 			},
 		},

--- a/internal/provider/test_http_server.go
+++ b/internal/provider/test_http_server.go
@@ -59,11 +59,13 @@ func setupTestServer(expectedItem *onepassword.Item, expectedVault onepassword.V
 		} else if r.Method == http.MethodPost {
 			if r.URL.String() == fmt.Sprintf("/v1/vaults/%s/items", expectedItem.Vault.ID) {
 				itemToReturn := convertBodyToItem(r, t)
-				itemField := onepassword.ItemField{
-					Label: "password",
-					Value: "somepassword",
+				if itemToReturn.Category != onepassword.SecureNote {
+					itemField := onepassword.ItemField{
+						Label: "password",
+						Value: "somepassword",
+					}
+					itemToReturn.Fields = append(itemToReturn.Fields, &itemField)
 				}
-				itemToReturn.Fields = append(itemToReturn.Fields, &itemField)
 
 				itemToReturn.ID = expectedItem.ID
 				itemBytes, err := json.Marshal(itemToReturn)


### PR DESCRIPTION
## Summary

In the case of Secure Note Items, the password is never set since it doesn't exist in that item category. This leaves the value it in the Unknown state throughout the creation process, which causes the provider to throw the following error:
```
╷
│ Error: Provider returned invalid result object after apply
│ 
│ After the apply operation, the provider still indicated an unknown value for onepassword_item.secure-note.password. All values must be known after apply, so this is always a bug in the provider and
│ should be reported in the provider's own repository. Terraform will still save the other known object values in the state.
╵
```

This PR sets it to null in such scenarios.

Resolves: #173 

## How to test

1. Checkout this branch:
   ```sh
   git pull && git checkout fix/throw-err-on-item-creation-fail
   ```
2. Build the provider:
   ```sh
   make build
   ```
3. Ensure that [your environment is configured to use the local provider](https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-provider#prepare-terraform-for-local-provider-install). Specifically, your `.terraform.rc` on macOS/Linux or `terraform.rc` on Windows contains this:
   ```
   provider_installation {
     dev_overrides {
         # other overrides
         "1Password/onepassword" = "path/to/terraform-provider-onepassword/dist"
     }
     # For all other providers, install them directly from their origin provider
     # registries as normal. If you omit this, Terraform will _only_ use
     # the dev_overrides block, and so no other providers will be available.
     direct {}
   }
   ```
4. Create a `main.tf` file with this content:
   ```tf
   terraform {
     required_providers {
       onepassword = {
         source = "1Password/onepassword"
         version = "~> 2.0.0"
       }
     }
   }

   data "onepassword_vault" "vault" {
     name = "<your-vault-name>"
   }

   resource "onepassword_item" "demo_login" {
     vault = data.onepassword_vault.vault.uuid

     title    = "Demo Terraform Secure Note"
     category = "secure_note"

     note_value = <<EOT
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec et volutpat lorem. Integer quis felis porttitor, lobortis purus id, sodales nisi. Suspendisse dictum nibh lorem, vel dapibus sapien sodales pulvinar. Donec euismod, dolor vitae fermentum faucibus, elit orci ullamcorper nisi, eget ultrices turpis elit non odio. Integer dictum risus ante, finibus venenatis sem varius bibendum. Sed pellentesque ultrices diam vel viverra. Duis odio mi, malesuada quis luctus a, lacinia quis orci. Vestibulum hendrerit lorem a odio tristique, quis blandit purus sollicitudin.

     Nullam ut hendrerit lacus, at consectetur risus. Vestibulum at diam a arcu fermentum eleifend vel at mi. Cras auctor, massa in blandit rutrum, risus nibh euismod massa, quis porttitor libero mauris id nibh. Sed lobortis ipsum in ipsum dapibus, commodo eleifend velit dignissim. Donec tincidunt turpis mi, vitae venenatis urna laoreet vel. Integer ut scelerisque massa, at varius est. Proin porta quam a dolor euismod, quis iaculis odio dictum. Cras velit neque, vestibulum et consequat at, ultrices quis enim. Nulla sed augue ac odio scelerisque facilisis. Nunc ultricies tristique eros et ullamcorper. Curabitur et est eu nibh viverra feugiat. Pellentesque viverra vitae lacus sed consectetur. Aliquam nec tempor ipsum, quis dapibus quam. Nulla suscipit enim vel porta egestas. Nulla interdum congue erat at fermentum. Quisque viverra tincidunt metus non malesuada.
     EOT
   }
   ```
5. Export the necessary environment variables for the authentication method that you want (Connect, service account or regular user)
6. Run `terraform apply`
   - [ ] The provider **should** successfully create the item with no errors.
