### PR TITLE
Export provider initialization function

### DIFF
--- a/providerlink/providerlink.go
+++ b/providerlink/providerlink.go
@@ -1,0 +1,9 @@
+package providerlink
+
+import (
+	"github.com/1Password/terraform-provider-onepassword/v2/internal/provider"
+)
+
+var (
+	New = provider.New
+)


### PR DESCRIPTION
In order to be able to use `New` function from `internal` package in the pulumi-provider, it's exported within `providerlink` package now.