### PR TITLE
Fix field reference from "label" to "id" for 1Password database items

### DIFF
--- a/internal/provider/onepassword_item_data_source.go
+++ b/internal/provider/onepassword_item_data_source.go
@@ -358,7 +358,7 @@ func (d *OnePasswordItemDataSource) Read(ctx context.Context, req datasource.Rea
 			data.NoteValue = types.StringValue(f.Value)
 		default:
 			if f.Section == nil {
-				switch f.Label {
+				switch f.ID {
 				case "username":
 					data.Username = types.StringValue(f.Value)
 				case "password":
@@ -369,11 +369,11 @@ func (d *OnePasswordItemDataSource) Read(ctx context.Context, req datasource.Rea
 					data.Database = types.StringValue(f.Value)
 				case "port":
 					data.Port = types.StringValue(f.Value)
-				case "type":
+				case "type", "database_type":
 					data.Type = types.StringValue(f.Value)
-				case "public key":
+				case "public_key":
 					data.PublicKey = types.StringValue(f.Value)
-				case "private key":
+				case "private_key":
 					data.PrivateKey = types.StringValue(f.Value)
 				}
 			}


### PR DESCRIPTION
Currently, the implementation retrieves the "label" field from 1Password database items. However, this causes issues with Japanese 1Password installations where database-type items have Japanese labels by default.

Looking at 1Password CLI commands like "op item get --fields password" and "op read", they reference fields by their "id" rather than "label". This suggests our current implementation of using "label" references may be incorrect.

We should modify the implementation to reference fields by their "id" instead of "label" for better compatibility and consistency with 1Password CLI behavior.

Sample JSON output showing Japanese labels is attached for reference.
```
op item get --vault testvault "test" --format json
{
  "id": "xxxxxxxxxxxxxxxxxxxxxxxxxx",
  "title": "test",
  "version": 1,
  "vault": {
    "id": "xxxxxxxxxxxxxxxxxxxxxxxxxx",
    "name": "testvault"
  },
  "category": "DATABASE",
  "last_edited_by": "xxxxxxxxxxxxxxxxxxxxxxxxxx",
  "created_at": "2025-02-26T12:06:31Z",
  "updated_at": "2025-02-26T12:06:31Z",
  "fields": [
    {
      "id": "notesPlain",
      "type": "STRING",
      "purpose": "NOTES",
      "label": "notesPlain",
      "reference": "op://testvault/test/notesPlain"
    },
    {
      "id": "database_type",
      "type": "MENU",
      "label": "種類",
      "reference": "op://testvault/test/database_type"
    },
    {
      "id": "hostname",
      "type": "STRING",
      "label": "サーバー",
      "reference": "op://testvault/test/hostname"
    },
    {
      "id": "port",
      "type": "STRING",
      "label": "ポート",
      "reference": "op://testvault/test/port"
    },
    {
      "id": "database",
      "type": "STRING",
      "label": "データベース",
      "reference": "op://testvault/test/database"
    },
    {
      "id": "username",
      "type": "STRING",
      "label": "ユーザ名",
      "reference": "op://testvault/test/username"
    },
    {
      "id": "password",
      "type": "CONCEALED",
      "label": "パスワード",
      "value": "abc",
      "reference": "op://testvault/test/password"
    },
    {
      "id": "sid",
      "type": "STRING",
      "label": "SID",
      "reference": "op://testvault/test/SID"
    },
    {
      "id": "alias",
      "type": "STRING",
      "label": "エイリアス",
      "reference": "op://testvault/test/alias"
    },
    {
      "id": "options",
      "type": "STRING",
      "label": "接続オプション",
      "reference": "op://testvault/test/options"
    }
  ]
}
```