### PR TITLE
SSH resource support

### DIFF
--- a/docs/resources/item.md
+++ b/docs/resources/item.md
@@ -45,13 +45,15 @@ resource "onepassword_item" "example" {
 
 ### Optional
 
-- `category` (String) The category of the item. One of ["login" "password" "database" "secure_note"]
+- `category` (String) The category of the item. One of ["login" "password" "database" "secure_note" "ssh_key"]
 - `database` (String) (Only applies to the database category) The name of the database.
 - `hostname` (String) (Only applies to the database category) The address where the database can be found
 - `note_value` (String, Sensitive) Secure Note value.
 - `password` (String, Sensitive) Password for this item.
 - `password_recipe` (Block List) The recipe used to generate a new value for a password. (see [below for nested schema](#nestedblock--password_recipe))
 - `port` (String) (Only applies to the database category) The port the database is listening on.
+- `private_key` (String, Sensitive) SSH Private Key for this item.
+- `public_key` (String) SSH Public Key for this item.
 - `section` (Block List) A list of custom sections in an item (see [below for nested schema](#nestedblock--section))
 - `tags` (List of String) An array of strings of the tags assigned to the item.
 - `title` (String) The title of the item.
@@ -65,6 +67,7 @@ resource "onepassword_item" "example" {
 - `uuid` (String) The UUID of the item. Item identifiers are unique within a specific vault.
 
 <a id="nestedblock--password_recipe"></a>
+
 ### Nested Schema for `password_recipe`
 
 Optional:
@@ -74,8 +77,8 @@ Optional:
 - `letters` (Boolean) Use letters [a-zA-Z] when generating the password.
 - `symbols` (Boolean) Use symbols [!@.-_*] when generating the password.
 
-
 <a id="nestedblock--section"></a>
+
 ### Nested Schema for `section`
 
 Required:
@@ -91,6 +94,7 @@ Read-Only:
 - `id` (String) A unique identifier for the section.
 
 <a id="nestedblock--section--field"></a>
+
 ### Nested Schema for `section.field`
 
 Required:
@@ -106,6 +110,7 @@ Optional:
 - `value` (String, Sensitive) The value of the field.
 
 <a id="nestedblock--section--field--password_recipe"></a>
+
 ### Nested Schema for `section.field.password_recipe`
 
 Optional:

--- a/internal/provider/onepassword_item_resource_test.go
+++ b/internal/provider/onepassword_item_resource_test.go
@@ -179,6 +179,36 @@ func TestAccItemResourceDocument(t *testing.T) {
 	})
 }
 
+func TestAccItemResourceSSHKey(t *testing.T) {
+	expectedItem := generateSSHKeyItem()
+	expectedVault := op.Vault{
+		ID:          expectedItem.Vault.ID,
+		Name:        "Name of the vault",
+		Description: "This vault will be retrieved",
+	}
+
+	testServer := setupTestServer(expectedItem, expectedVault, t)
+	defer testServer.Close()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig(testServer.URL) + testAccItemDataSourceConfig(expectedItem.Vault.ID, expectedItem.ID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.onepassword_item.test", "id", fmt.Sprintf("vaults/%s/items/%s", expectedVault.ID, expectedItem.ID)),
+					resource.TestCheckResourceAttr("data.onepassword_item.test", "vault", expectedVault.ID),
+					resource.TestCheckResourceAttr("data.onepassword_item.test", "title", expectedItem.Title),
+					resource.TestCheckResourceAttr("data.onepassword_item.test", "uuid", expectedItem.ID),
+					resource.TestCheckResourceAttr("data.onepassword_item.test", "category", strings.ToLower(string(expectedItem.Category))),
+					resource.TestCheckResourceAttr("data.onepassword_item.test", "private_key", expectedItem.Fields[0].Value),
+					resource.TestCheckResourceAttr("data.onepassword_item.test", "public_key", expectedItem.Fields[1].Value),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataBaseResourceConfig(expectedItem *op.Item) string {
 	return fmt.Sprintf(`
 


### PR DESCRIPTION
This PR builds on the work by @atammy-narmi for introducing [SSH as a data source](https://github.com/1Password/terraform-provider-onepassword/pull/158), whereas we here also add it as a resource.

My use case for this is to enable having all SSH key secrets stored inside a 1Password vault, and entirely forego the TF state for this sensitive information. 