### PR TITLE
Add data source tests for ssh key and document items

### DIFF
--- a/test/e2e/item_data_source_test.go
+++ b/test/e2e/item_data_source_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	tfconfig "github.com/1Password/terraform-provider-onepassword/v2/test/e2e/terraform/config"
-	"github.com/1Password/terraform-provider-onepassword/v2/test/e2e/utils"
+	"github.com/1Password/terraform-provider-onepassword/v2/test/e2e/utils/ssh"
 )
 
 const testVaultID = "bbucuyq2nn4fozygwttxwizpcy"
@@ -146,7 +146,7 @@ func TestAccItemDataSource(t *testing.T) {
 					publicKey := item.Primary.Attributes["public_key"]
 					privateKey := item.Primary.Attributes["private_key"]
 
-					return utils.ValidateSSHKeys(publicKey, privateKey)
+					return ssh.ValidateSSHKeys(publicKey, privateKey)
 				}))
 			}
 

--- a/test/e2e/utils/ssh/ssh.go
+++ b/test/e2e/utils/ssh/ssh.go
@@ -1,4 +1,4 @@
-package utils
+package ssh
 
 import (
 	"fmt"
@@ -17,7 +17,7 @@ func ValidateSSHKeys(publicKey string, privateKey string) error {
 		return fmt.Errorf("ssh_private_key attribute is not set")
 	}
 
-	_ , _, _, _, err := ssh.ParseAuthorizedKey([]byte(publicKey))
+	_, _, _, _, err := ssh.ParseAuthorizedKey([]byte(publicKey))
 	if err != nil {
 		return fmt.Errorf("invalid ssh public key: %s", err)
 	}
@@ -27,5 +27,5 @@ func ValidateSSHKeys(publicKey string, privateKey string) error {
 		return fmt.Errorf("invalid ssh private key: %s", err)
 	}
 
-	return  nil
+	return nil
 }


### PR DESCRIPTION
This PR adds E2E tests for the onepassword_item data source for SSH Key and Documents types with both lookup methods (Title and UUID).

### 🎯 Changes

- Update test cases in TestAccItemDataSource to use a helper in order to reduce repetitive test data.
- Add Document and SSHKey entries to testItems.
- Add test/e2e/utils/test_helpers.go with ValidateSSHKeys to parse/validate public and private SSH keys.



### 🔧 Benefits

- Less duplication; easier to add item types or lookup methods.
- Adds coverage for Document and SSH key items.