### PR TITLE
Fix eventual consistency issue in Connect's item get implementation

### DIFF
--- a/internal/onepassword/util/uuid.go
+++ b/internal/onepassword/util/uuid.go
@@ -1,0 +1,9 @@
+package util
+
+import "regexp"
+
+// IsValidUUID return 'true' if the provided string is valid 1Password UUID.
+func IsValidUUID(u string) bool {
+	r := regexp.MustCompile("^[a-z0-9]{26}$")
+	return r.MatchString(u)
+}


### PR DESCRIPTION
The current implementation of Connect's `GetItem` method has an issue as it could not find an item which has been just created via Connect. As connect has some delay between item creation and when it becomes available for reading. and terraform make subsequent read right after create.

Therefore implementation is changed to check if provided UUID is a valid UUID. If so, it tries to get item by UUID with retries. If could not found after 5 retries, it will tru to get item by title.

This fix will enable running e2e tests using Connect as auth method as well.