### PR TITLE
Trimming trailing newline from `op read` command output

### DIFF
--- a/internal/onepassword/cli/op.go
+++ b/internal/onepassword/cli/op.go
@@ -219,6 +219,12 @@ func (op *OP) GetFileContent(ctx context.Context, file *onepassword.File, itemUu
 	if err != nil {
 		return nil, err
 	}
+
+	// The op CLI command adds a trailing newline to its output, but the Connect API
+	// returns the raw file content without any trailing newline. To ensure consistency
+	// between both APIs, we remove a single trailing newline if present.
+	// This matches the behavior of the Connect API which returns the file content as stored.
+	res = bytes.TrimSuffix(res, []byte("\n"))
 	return res, nil
 }
 

--- a/test/e2e/item_data_source_test.go
+++ b/test/e2e/item_data_source_test.go
@@ -72,8 +72,8 @@ var testItems = map[op.ItemCategory]testItem{
 		Attrs: map[string]string{
 			"category":              "document",
 			"file.0.name":           "test.txt",
-			"file.0.content":        "This is a test\n",
-			"file.0.content_base64": "VGhpcyBpcyBhIHRlc3QK",
+			"file.0.content":        "This is a test",
+			"file.0.content_base64": "VGhpcyBpcyBhIHRlc3Q=",
 		},
 	},
 	op.SSHKey: {


### PR DESCRIPTION
### ✨ Summary

`op read` command adds new line `\n` when reading file content, but Connect returns file content as it as without adding `\n`. This make behavior inconsistent and leads to unexpected bugs.

This PR trims `\n` when reading file content using `op read`


### 🔗 Resolves:
n/a
<!-- What issue does it resolve? -->

### ✅ Checklist

- [x] 🖊️ Commits are signed
- [x] 🧪 Tests added/updated: _(See the [Testing Guide](docs/testing/testing.md) for when to use each type and how to run them)_
  - [x] 🔹 Unit /🔸 Integration
  - [ ] 🌐 E2E
- [ ] 📚 Docs updated (if behavior changed)

### 🕵️ Review Notes & ⚠️ Risks

<!-- Notes for reviewers, flags, feature gates, rollout considerations, etc. -->
