### PR TITLE
Update GetItemByTitle do directly call sdk

### DIFF
--- a/internal/onepassword/sdk/client.go
+++ b/internal/onepassword/sdk/client.go
@@ -96,7 +96,18 @@ func (c *Client) GetItemByTitle(ctx context.Context, title string, vaultUuid str
 		return nil, fmt.Errorf("found %d item(s) in vault %q with title %q", count, vaultUuid, title)
 	}
 
-	return c.GetItem(ctx, matchedID, vaultUuid)
+	sdkItem, err := c.sdkClient.Items().Get(ctx, vaultUuid, matchedID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get item using sdk: %w", err)
+	}
+
+	modelItem := &model.Item{}
+	err = modelItem.FromSDKItemToModel(&sdkItem)
+	if err != nil {
+		return nil, fmt.Errorf("sdk.GetItemByTitle failed to convert item using sdk: %w", err)
+	}
+
+	return modelItem, nil
 }
 
 func (c *Client) CreateItem(ctx context.Context, item *model.Item, vaultUuid string) (*model.Item, error) {


### PR DESCRIPTION
### ✨ Summary

- Update GetItemByTitle do directly call the SDK instead of calling GetItem

### 🔗 Resolves:

- In a case of an error there may have been an infinite loop between GetItemByTitle and GetItem

### ✅ Checklist

- [x] 🖊️ Commits are signed
- [ ] 🧪 Tests added/updated: _(See the [Testing Guide](docs/testing/testing.md) for when to use each type and how to run them)_
  - [ ] 🔹 Unit /🔸 Integration
  - [ ] 🌐 E2E
- [ ] 📚 Docs updated (if behavior changed)

### 🕵️ Review Notes & ⚠️ Risks

Note -> E2E is failing because we have hit account rate limit. This is being merged into a feature branch first whcih we will run E2E on before merging to main. 
