### PR TITLE
Add ID to test data

### DIFF
--- a/internal/provider/test_utils.go
+++ b/internal/provider/test_utils.go
@@ -150,26 +150,32 @@ func generateLoginItemWithFiles() *model.Item {
 func generateDatabaseFields() []model.ItemField {
 	fields := []model.ItemField{
 		{
+			ID:    "username",
 			Label: "username",
 			Value: "test_user",
 		},
 		{
+			ID:    "password",
 			Label: "password",
 			Value: "test_password",
 		},
 		{
+			ID:    "hostname",
 			Label: "hostname",
 			Value: "test_host",
 		},
 		{
+			ID:    "database",
 			Label: "database",
 			Value: "test_database",
 		},
 		{
+			ID:    "port",
 			Label: "port",
 			Value: "test_port",
 		},
 		{
+			ID:    "type",
 			Label: "type",
 			Value: "mysql",
 		},
@@ -180,10 +186,12 @@ func generateDatabaseFields() []model.ItemField {
 func generatePasswordFields() []model.ItemField {
 	fields := []model.ItemField{
 		{
+			ID:    "username",
 			Label: "username",
 			Value: "test_user",
 		},
 		{
+			ID:    "password",
 			Label: "password",
 			Value: "test_password",
 		},
@@ -194,10 +202,12 @@ func generatePasswordFields() []model.ItemField {
 func generateLoginFields() []model.ItemField {
 	fields := []model.ItemField{
 		{
+			ID:    "username",
 			Label: "username",
 			Value: "test_user",
 		},
 		{
+			ID:    "password",
 			Label: "password",
 			Value: "test_password",
 		},
@@ -220,10 +230,12 @@ func generateSSHKeyFields() []model.ItemField {
 
 	fields := []model.ItemField{
 		{
+			ID:    "private_key",
 			Label: "private key",
 			Value: string(pem.EncodeToMemory(privateKeyPem)),
 		},
 		{
+			ID:    "public_key",
 			Label: "public key",
 			Value: publicKey,
 		},


### PR DESCRIPTION
### ✨ Summary

- This adds IDs to test data fields in order to fix build failures. This [PR](https://github.com/1Password/terraform-provider-onepassword/pull/213) switches to use ID instead of label.

### 🔗 Resolves:

<!-- What issue does it resolve? -->

### ✅ Checklist

- [x] 🖊️ Commits are signed
- [ ] 🧪 Tests added/updated: _(See the [Testing Guide](docs/testing/testing.md) for when to use each type and how to run them)_
  - [x] 🔹 Unit /🔸 Integration
  - [ ] 🌐 E2E
- [ ] 📚 Docs updated (if behavior changed)

### 🕵️ Review Notes & ⚠️ Risks

<!-- Notes for reviewers, flags, feature gates, rollout considerations, etc. -->
