### PR TITLE
Skip running e2e tests for PRs created by depenabot

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -39,7 +39,10 @@ jobs:
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             # For pull_request events, check if PR is from external fork
             echo "PR head repo: ${{ github.event.pull_request.head.repo.full_name }}"
-            if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            if [ "${{ github.actor }}" == "dependabot[bot]" ]; then
+              echo "condition=skip" >> $GITHUB_OUTPUT
+              echo "Setting condition=skip (Dependabot PR)"
+            elif [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
               echo "condition=skip" >> $GITHUB_OUTPUT
               echo "Setting condition=skip (external fork PR creation)"
             else


### PR DESCRIPTION
### ✨ Summary
When PR is created by depenabot ([example](https://github.com/1Password/terraform-provider-onepassword/pull/275)), it still tries to run e2e tests, which are failed as secrets are not available in the workflows triggered by bots.

This PR make `Check if PR is from external contributor` step to skip running e2e tests for PRs created by depenabot.

### 🔗 Resolves:

<!-- What issue does it resolve? -->

### ✅ Checklist

- [x] 🖊️ Commits are signed
- [ ] 🧪 Tests added/updated: _(See the [Testing Guide](docs/testing/testing.md) for when to use each type and how to run them)_
  - [ ] 🔹 Unit /🔸 Integration
  - [ ] 🌐 E2E
- [ ] 📚 Docs updated (if behavior changed)

### 🕵️ Review Notes & ⚠️ Risks

<!-- Notes for reviewers, flags, feature gates, rollout considerations, etc. -->
