### PR TITLE
Fix goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,6 +33,8 @@ builds:
         goarch: "386"
       - goos: freebsd
         goarch: "386"
+      - goos: freebsd
+        goarch: arm
       - goos: windows
         goarch: arm
     binary: "{{ .ProjectName }}_v{{ .Version }}"


### PR DESCRIPTION
### ✨ Summary

1. Fixes indents
2. Builds for goarm 7 only.
     - ARMv7 covers most modern 32-bit ARM devices including Raspberry Pi 2+, modern embedded Linux systems, and most ARM-based IoT devices. ARMv6 is legacy.
3. Ignore `freebsd/arm` as it cases issues with `onepassword-sdk-go` dependency. 

### 🔗 Resolves:

<!-- What issue does it resolve? -->

### ✅ Checklist

- [x] 🖊️ Commits are signed
- [ ] 🧪 Tests added/updated: _(See the [Testing Guide](docs/testing/testing.md) for when to use each type and how to run them)_
  - [ ] 🔹 Unit /🔸 Integration
  - [ ] 🌐 E2E
- [ ] 📚 Docs updated (if behavior changed)

### 🕵️ Review Notes & ⚠️ Risks

<!-- Notes for reviewers, flags, feature gates, rollout considerations, etc. -->
