### PR TITLE
Add E2E test for password generation per category

### DIFF
--- a/test/e2e/item_resource_test.go
+++ b/test/e2e/item_resource_test.go
@@ -949,16 +949,6 @@ func TestAccItemResourcePasswordGenerationForAllCategories(t *testing.T) {
 						),
 						Check: resource.ComposeAggregateTestCheckFunc(checks...),
 					},
-					// Second apply to verify password is stable (not regenerated)
-					{
-						Config: tfconfig.CreateConfigBuilder()(
-							tfconfig.ProviderConfig(),
-							tfconfig.ItemResourceConfig(testVaultID, attrs),
-						),
-						Check: resource.ComposeAggregateTestCheckFunc(
-							resource.TestCheckResourceAttrSet("onepassword_item.test_item", "password"),
-						),
-					},
 				},
 			})
 		})


### PR DESCRIPTION
### ✨ Summary

- We updated the provider to use 1Password SDKs which has resolved this issue. There was logic issue with the CLI parsing the password recipe data, which now does not apply as it has been deprecated.
- I have added E2E coverage here to ensure categories that allow password recipes all work as expected. 

### 🔗 Resolves:

https://github.com/1Password/terraform-provider-onepassword/issues/129

### ✅ Checklist

- [x] 🖊️ Commits are signed
- [x] 🧪 Tests added/updated: _(See the [Testing Guide](docs/testing/testing.md) for when to use each type and how to run them)_
  - [ ] 🔹 Unit /🔸 Integration
  - [x] 🌐 E2E
- [ ] 📚 Docs updated (if behavior changed)

### 🕵️ Review Notes & ⚠️ Risks

<!-- Notes for reviewers, flags, feature gates, rollout considerations, etc. -->
