### PR TITLE
Update to enforce case sensitivity on field types

### DIFF
--- a/internal/provider/onepassword_item_resource.go
+++ b/internal/provider/onepassword_item_resource.go
@@ -264,7 +264,7 @@ func (r *OnePasswordItemResource) Schema(ctx context.Context, req resource.Schem
 										Computed:            true,
 										Default:             stringdefault.StaticString("STRING"),
 										Validators: []validator.String{
-											stringvalidator.OneOfCaseInsensitive(fieldTypes...),
+											stringvalidator.OneOf(fieldTypes...),
 										},
 									},
 									"value": schema.StringAttribute{


### PR DESCRIPTION
### ✨ Summary

- Users are able to submit lowercase types even though that is not an accepted value, and our [documentation](https://registry.terraform.io/providers/1Password/onepassword/latest/docs/resources/item#:~:text=type%20(String)%20The%20type%20of%20value%20stored%20in%20the%20field.%20One%20of%20%5B%22STRING%22%20%22CONCEALED%22%20%22EMAIL%22%20%22URL%22%20%22OTP%22%20%22DATE%22%20%22MONTH_YEAR%22%20%22MENU%22%5D) indicates it needs to be uppercase. This results in an error from Connect/SDK.
- To resolve this I have updated to enforce that type is one of the FieldTypes, which results in provider throwing an error prompting users to use the correct type:
<img width="773" height="48" alt="image" src="https://github.com/user-attachments/assets/01acaad4-4381-414b-a9a8-6e873c443b63" />


### 🔗 Resolves:

Resolves: https://github.com/1Password/terraform-provider-onepassword/issues/214

### ✅ Checklist

- [x] 🖊️ Commits are signed
- [ ] 🧪 Tests added/updated: _(See the [Testing Guide](docs/testing/testing.md) for when to use each type and how to run them)_
  - [ ] 🔹 Unit /🔸 Integration
  - [ ] 🌐 E2E
- [ ] 📚 Docs updated (if behavior changed)

### 🕵️ Review Notes & ⚠️ Risks

<!-- Notes for reviewers, flags, feature gates, rollout considerations, etc. -->
