### PR TITLE
Add test cleanup helper

### DIFF
--- a/test/e2e/item_data_source_test.go
+++ b/test/e2e/item_data_source_test.go
@@ -15,6 +15,7 @@ import (
 	tfconfig "github.com/1Password/terraform-provider-onepassword/v2/test/e2e/terraform/config"
 	"github.com/1Password/terraform-provider-onepassword/v2/test/e2e/utils/attributes"
 	"github.com/1Password/terraform-provider-onepassword/v2/test/e2e/utils/checks"
+	"github.com/1Password/terraform-provider-onepassword/v2/test/e2e/utils/cleanup"
 	"github.com/1Password/terraform-provider-onepassword/v2/test/e2e/utils/client"
 	"github.com/1Password/terraform-provider-onepassword/v2/test/e2e/utils/sections"
 	"github.com/1Password/terraform-provider-onepassword/v2/test/e2e/utils/ssh"
@@ -375,7 +376,8 @@ func TestAccItemDataSource_DetectManualChanges(t *testing.T) {
 					tfconfig.ItemResourceConfig(testVaultID, initialAttrs),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					uuidutil.CaptureItemUUIDAndRegisterCleanup(t, "onepassword_item.test_item", &itemUUID, testVaultID),
+					uuidutil.CaptureItemUUID(t, "onepassword_item.test_item", &itemUUID),
+					cleanup.RegisterItem(t, &itemUUID, testVaultID),
 				),
 			},
 			// Read item with data source

--- a/test/e2e/item_resource_test.go
+++ b/test/e2e/item_resource_test.go
@@ -15,6 +15,7 @@ import (
 	tfconfig "github.com/1Password/terraform-provider-onepassword/v2/test/e2e/terraform/config"
 	"github.com/1Password/terraform-provider-onepassword/v2/test/e2e/utils/attributes"
 	"github.com/1Password/terraform-provider-onepassword/v2/test/e2e/utils/checks"
+	"github.com/1Password/terraform-provider-onepassword/v2/test/e2e/utils/cleanup"
 	"github.com/1Password/terraform-provider-onepassword/v2/test/e2e/utils/client"
 	"github.com/1Password/terraform-provider-onepassword/v2/test/e2e/utils/password"
 	"github.com/1Password/terraform-provider-onepassword/v2/test/e2e/utils/sections"
@@ -138,7 +139,8 @@ func TestAccItemResource(t *testing.T) {
 			// Build check functions for create step
 			createChecks := []resource.TestCheckFunc{
 				logStep(t, "CREATE"),
-				uuidutil.CaptureItemUUIDAndRegisterCleanup(t, "onepassword_item.test_item", &itemUUID, testVaultID),
+				uuidutil.CaptureItemUUID(t, "onepassword_item.test_item", &itemUUID),
+				cleanup.RegisterItem(t, &itemUUID, testVaultID),
 			}
 			bcCreate := checks.BuildItemChecks("onepassword_item.test_item", createAttrs)
 			createChecks = append(createChecks, bcCreate...)
@@ -250,7 +252,8 @@ func TestAccItemResourcePasswordGeneration(t *testing.T) {
 				} else {
 					var itemUUID string
 					checks := []resource.TestCheckFunc{
-						uuidutil.CaptureItemUUIDAndRegisterCleanup(t, "onepassword_item.test_item", &itemUUID, testVaultID),
+						uuidutil.CaptureItemUUID(t, "onepassword_item.test_item", &itemUUID),
+						cleanup.RegisterItem(t, &itemUUID, testVaultID),
 					}
 					checks = append(checks, password.BuildPasswordRecipeChecks("onepassword_item.test_item", tc.recipe)...)
 					testStep.Check = resource.ComposeAggregateTestCheckFunc(checks...)
@@ -367,7 +370,8 @@ func TestAccItemResourceSectionFieldPasswordGeneration(t *testing.T) {
 			} else {
 				var itemUUID string
 				checks := []resource.TestCheckFunc{
-					uuidutil.CaptureItemUUIDAndRegisterCleanup(t, "onepassword_item.test_item", &itemUUID, testVaultID),
+					uuidutil.CaptureItemUUID(t, "onepassword_item.test_item", &itemUUID),
+					cleanup.RegisterItem(t, &itemUUID, testVaultID),
 				}
 				checks = append(checks, password.BuildPasswordRecipeChecksForField("onepassword_item.test_item", "section.0.field.0", tc.recipe)...)
 				testStep.Check = resource.ComposeAggregateTestCheckFunc(checks...)
@@ -514,7 +518,8 @@ func TestAccItemResourceSectionsAndFields(t *testing.T) {
 				// Build check functions for create step
 				createChecks := []resource.TestCheckFunc{
 					logStep(t, "CREATE"),
-					uuidutil.CaptureItemUUIDAndRegisterCleanup(t, "onepassword_item.test_item", &itemUUID, testVaultID),
+					uuidutil.CaptureItemUUID(t, "onepassword_item.test_item", &itemUUID),
+					cleanup.RegisterItem(t, &itemUUID, testVaultID),
 				}
 				createChecks = append(createChecks, checks.BuildItemChecks("onepassword_item.test_item", createAttrs)...)
 
@@ -581,7 +586,8 @@ func TestAccItemResourceTags(t *testing.T) {
 		// Capture UUID and register cleanup
 		if i == 0 {
 			testChecks = append(testChecks,
-				uuidutil.CaptureItemUUIDAndRegisterCleanup(t, "onepassword_item.test_item", &itemUUID, testVaultID),
+				uuidutil.CaptureItemUUID(t, "onepassword_item.test_item", &itemUUID),
+				cleanup.RegisterItem(t, &itemUUID, testVaultID),
 			)
 		}
 
@@ -619,7 +625,8 @@ func TestAccRecreateNonExistingItem(t *testing.T) {
 	// Build check functions for create step
 	createChecks := []resource.TestCheckFunc{
 		logStep(t, "CREATE"),
-		uuidutil.CaptureItemUUIDAndRegisterCleanup(t, "onepassword_item.test_item", &itemUUID, testVaultID),
+		uuidutil.CaptureItemUUID(t, "onepassword_item.test_item", &itemUUID),
+		cleanup.RegisterItem(t, &itemUUID, testVaultID),
 	}
 	bcCreate := checks.BuildItemChecks("onepassword_item.test_item", createAttrs)
 	createChecks = append(createChecks, bcCreate...)
@@ -652,7 +659,8 @@ func TestAccRecreateNonExistingItem(t *testing.T) {
 	// Build check functions for recreate step - verify the item was recreated
 	recreateChecks := []resource.TestCheckFunc{
 		logStep(t, "RECREATE"),
-		uuidutil.CaptureItemUUIDAndRegisterCleanup(t, "onepassword_item.test_item", &itemUUID, testVaultID),
+		uuidutil.CaptureItemUUID(t, "onepassword_item.test_item", &itemUUID),
+		cleanup.RegisterItem(t, &itemUUID, testVaultID),
 	}
 	bcRecreate := checks.BuildItemChecks("onepassword_item.test_item", createAttrs)
 	recreateChecks = append(recreateChecks, bcRecreate...)
@@ -734,7 +742,8 @@ func TestAccItemResource_DetectManualChanges(t *testing.T) {
 	// Build check functions for create step
 	createChecks := []resource.TestCheckFunc{
 		logStep(t, "CREATE"),
-		uuidutil.CaptureItemUUIDAndRegisterCleanup(t, "onepassword_item.test_item", &itemUUID, testVaultID),
+		uuidutil.CaptureItemUUID(t, "onepassword_item.test_item", &itemUUID),
+		cleanup.RegisterItem(t, &itemUUID, testVaultID),
 	}
 	bcCreate := checks.BuildItemChecks("onepassword_item.test_item", initialAttrs)
 	createChecks = append(createChecks, bcCreate...)
@@ -957,7 +966,8 @@ func TestAccItemResourcePasswordGenerationForAllCategories(t *testing.T) {
 
 			// Build checks to verify password was generated
 			checks := []resource.TestCheckFunc{
-				uuidutil.CaptureItemUUIDAndRegisterCleanup(t, "onepassword_item.test_item", &itemUUID, testVaultID),
+				uuidutil.CaptureItemUUID(t, "onepassword_item.test_item", &itemUUID),
+				cleanup.RegisterItem(t, &itemUUID, testVaultID),
 			}
 			checks = append(checks, password.BuildPasswordRecipeChecks("onepassword_item.test_item", recipe)...)
 			checks = append(checks, resource.TestCheckResourceAttrSet("onepassword_item.test_item", "password"))
@@ -1014,7 +1024,8 @@ func TestAccItemResourceEmptyStringPreservation(t *testing.T) {
 					tfconfig.ItemResourceConfig(testVaultID, attrs),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					uuidutil.CaptureItemUUIDAndRegisterCleanup(t, "onepassword_item.test_item", &itemUUID, testVaultID),
+					uuidutil.CaptureItemUUID(t, "onepassword_item.test_item", &itemUUID),
+					cleanup.RegisterItem(t, &itemUUID, testVaultID),
 					resource.TestCheckResourceAttr("onepassword_item.test_item", "title", ""),
 					resource.TestCheckResourceAttr("onepassword_item.test_item", "username", ""),
 					resource.TestCheckResourceAttr("onepassword_item.test_item", "url", ""),
@@ -1048,7 +1059,8 @@ func TestAccItemResourceNullVsEmptyString(t *testing.T) {
 					tfconfig.ItemResourceConfig(testVaultID, attrsWithoutFields),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					uuidutil.CaptureItemUUIDAndRegisterCleanup(t, "onepassword_item.test_item", &itemUUID, testVaultID),
+					uuidutil.CaptureItemUUID(t, "onepassword_item.test_item", &itemUUID),
+					cleanup.RegisterItem(t, &itemUUID, testVaultID),
 					resource.TestCheckNoResourceAttr("onepassword_item.test_item", "username"),
 					resource.TestCheckNoResourceAttr("onepassword_item.test_item", "url"),
 					resource.TestCheckNoResourceAttr("onepassword_item.test_item", "hostname"),
@@ -1120,7 +1132,8 @@ func TestAccItemResourceClearFieldsToEmptyString(t *testing.T) {
 					tfconfig.ItemResourceConfig(testVaultID, attrsWithValues),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					uuidutil.CaptureItemUUIDAndRegisterCleanup(t, "onepassword_item.test_item", &itemUUID, testVaultID),
+					uuidutil.CaptureItemUUID(t, "onepassword_item.test_item", &itemUUID),
+					cleanup.RegisterItem(t, &itemUUID, testVaultID),
 					resource.TestCheckResourceAttr("onepassword_item.test_item", "username", "testuser"),
 					resource.TestCheckResourceAttr("onepassword_item.test_item", "hostname", "db.example.com"),
 					resource.TestCheckResourceAttr("onepassword_item.test_item", "database", "mydb"),

--- a/test/e2e/utils/cleanup/cleanup.go
+++ b/test/e2e/utils/cleanup/cleanup.go
@@ -2,42 +2,55 @@ package cleanup
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/1Password/terraform-provider-onepassword/v2/internal/onepassword/model"
 	"github.com/1Password/terraform-provider-onepassword/v2/test/e2e/utils/client"
 )
 
-// RegisterItemCleanup registers a cleanup function that will delete an item even if the test fails.
-func RegisterItemCleanup(t *testing.T, itemUUID, vaultID string) {
-	if itemUUID == "" {
-		return
+// RegisterItem registers a cleanup function that will delete an item even if the test fails
+func RegisterItem(t *testing.T, uuidPtr *string, vaultID string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if uuidPtr == nil || *uuidPtr == "" {
+			return fmt.Errorf("cleanup: item UUID is empty")
+		}
+
+		itemUUID := *uuidPtr
+		t.Cleanup(func() {
+			// Only delete if test failed because if test succeeded Terraform already deleted it
+			if !t.Failed() {
+				return
+			}
+
+			ctx := context.Background()
+			testClient, err := client.CreateTestClient(ctx)
+			if err != nil {
+				t.Logf("Cleanup: failed to create client for item %s: %v", itemUUID, err)
+				return
+			}
+
+			itemToDelete := &model.Item{
+				ID:      itemUUID,
+				VaultID: vaultID,
+			}
+
+			// Try to delete, retry once after 1s if it fails
+			err = testClient.DeleteItem(ctx, itemToDelete, vaultID)
+			if err != nil {
+				time.Sleep(1 * time.Second)
+				err = testClient.DeleteItem(ctx, itemToDelete, vaultID)
+				if err != nil {
+					t.Logf("Cleanup: failed to delete item %s: %v", itemUUID, err)
+					return
+				}
+			}
+		})
+
+		return nil
 	}
-
-	t.Cleanup(func() {
-		// Only delete if test failed because if test succeeded Terraform already deleted it
-		if !t.Failed() {
-			return
-		}
-
-		ctx := context.Background()
-		testClient, err := client.CreateTestClient(ctx)
-		if err != nil {
-			t.Logf("Cleanup: failed to create client for item %s: %v", itemUUID, err)
-			return
-		}
-
-		itemToDelete := &model.Item{
-			ID:      itemUUID,
-			VaultID: vaultID,
-		}
-
-		// Try to delete, retry once after 1s if it fails
-		err = testClient.DeleteItem(ctx, itemToDelete, vaultID)
-		if err != nil {
-			time.Sleep(1 * time.Second)
-			_ = testClient.DeleteItem(ctx, itemToDelete, vaultID)
-		}
-	})
 }

--- a/test/e2e/utils/uuid/uuid.go
+++ b/test/e2e/utils/uuid/uuid.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-
-	"github.com/1Password/terraform-provider-onepassword/v2/test/e2e/utils/cleanup"
 )
 
 // CaptureItemUUID captures the UUID of a resource item
@@ -48,20 +46,6 @@ func VerifyItemUUIDUnchanged(t *testing.T, resourceName string, expectedUUID *st
 			return fmt.Errorf("UUID changed from %s to %s - resource was replaced instead of updated", *expectedUUID, currentUUID)
 		}
 
-		return nil
-	}
-}
-
-// CaptureItemUUIDAndRegisterCleanup captures the UUID and registers cleanup
-func CaptureItemUUIDAndRegisterCleanup(t *testing.T, resourceName string, uuidPtr *string, vaultID string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		captureUUIDFunc := CaptureItemUUID(t, resourceName, uuidPtr)
-		err := captureUUIDFunc(s)
-		if err != nil {
-			return err
-		}
-
-		cleanup.RegisterItemCleanup(t, *uuidPtr, vaultID)
 		return nil
 	}
 }


### PR DESCRIPTION
### ✨ Summary

- Certain cases where a 409 / 500 error occur from 1Password the test fails and items are left abandoned in the test vault.
- This PR adds a test clean up method which executes if an E2E test fails which captures the UUID and registers clean up.

Note we already have retries for 409s in the provider. But DELETE unfortunately returns generic 500 response on 409 conflict. This should cleanup issues where item is abandoned on DELETE error.

### 🔗 Resolves:

Resolves: https://github.com/1Password/terraform-provider-onepassword/issues/274

### ✅ Checklist

- [x] 🖊️ Commits are signed
- [x] 🧪 Tests added/updated: _(See the [Testing Guide](docs/testing/testing.md) for when to use each type and how to run them)_
  - [ ] 🔹 Unit /🔸 Integration
  - [x] 🌐 E2E
- [ ] 📚 Docs updated (if behavior changed)

### 🕵️ Review Notes & ⚠️ Risks

To test this change checkout the branch locally to run tests as well as rerunning the E2E workflow on this pipeline. There will be sporadic 500 failures but no items should be left abandoned. 

I tested running the job and tests locally several times with failures to ensure all items are cleaned up.
