### PR TITLE
Ensure test vault Id syncs before running tests

### DIFF
--- a/test/e2e/item_resource_test.go
+++ b/test/e2e/item_resource_test.go
@@ -109,10 +109,13 @@ var testItemsUpdatedAttrs = map[model.ItemCategory]map[string]any{
 }
 
 func TestMain(m *testing.M) {
-	// Initialize early if using custom vault (prevents race conditions in parallel tests)
+	// Initialize vault early if using custom vault (prevents race conditions in parallel tests)
 	// for default vault, this is instant as we already have the ID
-	vault.GetTestVaultID(nil)
-
+	err := vault.InitTestVaultID()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to initialize test vault: %v\n", err)
+		os.Exit(1)
+	}
 	code := m.Run()
 	os.Exit(code)
 }

--- a/test/e2e/utils/vault/vault.go
+++ b/test/e2e/utils/vault/vault.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"sync"
 	"testing"
@@ -12,12 +13,13 @@ import (
 var (
 	testVaultIDOnce sync.Once
 	testVaultID     string
+	testVaultIDErr  error
 )
 
 const defaultTestVaultID = "bbucuyq2nn4fozygwttxwizpcy"
 
-// GetTestVaultID returns the vault ID by querying by name once and caching the result or returns default ID of the terraform-provider-acceptance-tests vault.
-func GetTestVaultID(t *testing.T) string {
+// InitTestVaultID initializes the vault ID. Returns error if initialization fails.
+func InitTestVaultID() error {
 	testVaultIDOnce.Do(func() {
 		vaultName := os.Getenv("OP_TEST_VAULT_NAME")
 		if vaultName == "" {
@@ -28,22 +30,37 @@ func GetTestVaultID(t *testing.T) string {
 		ctx := context.Background()
 		client, err := client.CreateTestClient(ctx)
 		if err != nil {
-			t.Fatalf("failed to create test client: %v", err)
+			testVaultIDErr = fmt.Errorf("failed to create test client: %w", err)
+			return
 		}
 
 		vaults, err := client.GetVaultsByTitle(ctx, vaultName)
 		if err != nil {
-			t.Fatalf("failed to get vault by name %q: %v", vaultName, err)
+			testVaultIDErr = fmt.Errorf("failed to get vault by name %q: %w", vaultName, err)
+			return
 		}
 
 		if len(vaults) == 0 {
-			t.Fatalf("no vault found with name %q", vaultName)
+			testVaultIDErr = fmt.Errorf("no vault found with name %q", vaultName)
+			return
 		}
 		if len(vaults) > 1 {
-			t.Fatalf("multiple vaults found with name %q", vaultName)
+			testVaultIDErr = fmt.Errorf("multiple vaults found with name %q", vaultName)
+			return
 		}
 
 		testVaultID = vaults[0].ID
 	})
+
+	return testVaultIDErr
+}
+
+// GetTestVaultID returns the vault ID.
+func GetTestVaultID(t *testing.T) string {
+	err := InitTestVaultID()
+	if err != nil {
+		t.Fatalf("failed to get test vault ID: %v", err)
+	}
+
 	return testVaultID
 }


### PR DESCRIPTION
### ✨ Summary

- Now that all tests run in parallel there seemed to be an issue an issue with the test Vault not being provided. This was due to GetTestVaultID querying multiple times simultaneously and then caching an empty response. See [here](https://github.com/1Password/terraform-provider-onepassword/actions/runs/20935893012/job/60158298967?pr=313). 
- To fix this I have added a TestMain to initialize the vault before running the tests. 

### 🔗 Resolves:

<!-- What issue does it resolve? -->

### ✅ Checklist

- [x] 🖊️ Commits are signed
- [x] 🧪 Tests added/updated: _(See the [Testing Guide](docs/testing/testing.md) for when to use each type and how to run them)_
  - [ ] 🔹 Unit /🔸 Integration
  - [x] 🌐 E2E
- [ ] 📚 Docs updated (if behavior changed)

### 🕵️ Review Notes & ⚠️ Risks

<!-- Notes for reviewers, flags, feature gates, rollout considerations, etc. -->
