### PR TITLE
Do not run e2e tests on version change

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -10,6 +10,8 @@ on:
       - ".gitignore"
       - "LICENSE"
       - "scripts/**"
+      - ".VERSION"
+      - "version/version.go"
   pull_request:
     types: [opened, synchronize, reopened]
     branches: ["**"] # run for PRs targeting any branch


### PR DESCRIPTION
### ✨ Summary

This is useful when making release PRs. As we need to bump version in `.VERSION` and `version/version.go` but it doesn't affect provider functionality at all.

<!-- What does this change do? -->

### 🔗 Resolves:

<!-- What issue does it resolve? -->

### ✅ Checklist

- [x] 🖊️ Commits are signed
- [ ] 🧪 Tests added/updated: _(See the [Testing Guide](docs/testing/testing.md) for when to use each type and how to run them)_
  - [ ] 🔹 Unit /🔸 Integration
  - [ ] 🌐 E2E
- [ ] 📚 Docs updated (if behavior changed)

### 🕵️ Review Notes & ⚠️ Risks

<!-- Notes for reviewers, flags, feature gates, rollout considerations, etc. -->
