### PR TITLE
Add temporary fallback to GetVault 

### DIFF
--- a/internal/onepassword/sdk/client.go
+++ b/internal/onepassword/sdk/client.go
@@ -32,7 +32,7 @@ func (c *Client) GetVault(ctx context.Context, uuid string) (*model.Vault, error
 			decryptDetails := true
 			vaultList, listErr := c.sdkClient.Vaults().List(ctx, sdk.VaultListParams{DecryptDetails: &decryptDetails})
 			if listErr != nil {
-				return nil, fmt.Errorf("failed to get vault using sdk: %w (fallback list also failed: %v)", err, listErr)
+				return nil, fmt.Errorf("failed to get vault using sdk: %w (fallback list failed: %v)", err, listErr)
 			}
 
 			// Find vault with matching UUID
@@ -47,7 +47,7 @@ func (c *Client) GetVault(ctx context.Context, uuid string) (*model.Vault, error
 			return nil, fmt.Errorf("failed to get vault using sdk: %w (vault with UUID %q not found in fallback list)", err, uuid)
 		}
 
-		return nil, fmt.Errorf("failed to get vault using sdk: %w (vault with UUID %q not found in fallback list)", err, uuid)
+		return nil, fmt.Errorf("failed to get vault using sdk: %w", err)
 	}
 
 	v := &model.Vault{}


### PR DESCRIPTION
### ✨ Summary

When trying to access vault directly with desktop auth error is returned:
```
failed to get vault using sdk: data did not match any
│ variant of untagged enum Invocation at line 1 column 129
```
Recent changes to beta SDK result in this new error. A fix will be shipped before stable release but until then we should add this fallback to list all vaults and extract one we want to unblock Provider users.

### 🔗 Resolves:

Resolves: https://github.com/1Password/terraform-provider-onepassword/issues/310

### ✅ Checklist

- [x] 🖊️ Commits are signed
- [ ] 🧪 Tests added/updated: _(See the [Testing Guide](docs/testing/testing.md) for when to use each type and how to run them)_
  - [ ] 🔹 Unit /🔸 Integration
  - [ ] 🌐 E2E
- [ ] 📚 Docs updated (if behavior changed)

### 🕵️ Review Notes & ⚠️ Risks

To reproduce this bug attempt to access a vault directly using the SDK with OP_ACCOUNT with name or uuid. It will produce an error. 

```
data "onepassword_vault" "test_vault" {
  #name = <your-vault-name>
  uuid = <your-vault-uuid>
}
```

With the changes here we will fallback to working `Vault().List()` in order to get vault info.

