### PR TITLE
Increase Connect sync timeout

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -51,7 +51,7 @@ jobs:
             --set connect.create=true \
             --set-file connect.credentials=1password-credentials.json \
             --set operator.create=false \
-            --set operator.authMethod=connect
+            --set operator.authMethod=connect \
             --set connect.api.env.OP_SYNC_TIMEOUT=1m
 
       - name: Wait for Connect service to be ready


### PR DESCRIPTION
### ✨ Summary

Even after removing parallel test runs I noticed we were still receiving `408: sync did not complete within timeout, please retry the request` on the first few tests that run with Connect. Example [here](https://github.com/1Password/terraform-provider-onepassword/actions/runs/21146003684/job/60811629555?pr=323).

I did some digging and this occurs when Connect sync can't finish before the default timeout is hit which is 10s. This timeout can be updated by using [OP_SYNC_TIMEOUT](https://developer.1password.com/docs/connect/server-configuration/#:~:text=The%20time%20(in%20seconds)%20to%20wait%20for%20the%20initial%20sync%20to%20complete.%0A%0AAcceptable%20values%3A%20A%20time%20duration%20(for%20example%2C%201h%2C%2030m%2C%2020s).%0ADefault%20value%3A%2010s%20(10%20seconds)) so I have increased it in order to avoid failures with Connect tests runs.

### 🔗 Resolves:

<!-- What issue does it resolve? -->

### ✅ Checklist

- [x] 🖊️ Commits are signed
- [x] 🧪 Tests added/updated: _(See the [Testing Guide](docs/testing/testing.md) for when to use each type and how to run them)_
  - [ ] 🔹 Unit /🔸 Integration
  - [x] 🌐 E2E
- [ ] 📚 Docs updated (if behavior changed)

### 🕵️ Review Notes & ⚠️ Risks

This is hard to test but I reran e2e workflow a couple of times with this change and didn't run into failures with Connect.
