### PR TITLE
Add onepassword_items data source for batch-reading items

### DIFF
--- a/docs/data-sources/items.md
+++ b/docs/data-sources/items.md
@@ -1,0 +1,58 @@
+---
+page_title: "onepassword_items Data Source - onepassword"
+subcategory: ""
+description: |-
+  Use this to batch-read multiple items from a vault. Returns item details and a convenience credentials map.
+---
+
+# onepassword_items (Data Source)
+
+Use this to batch-read multiple items from a vault by their titles or UUIDs. This is more efficient than using multiple `onepassword_item` data sources with `for_each`, as it reduces Terraform configuration boilerplate and provides a convenient `credentials` map for the common case of reading secret values.
+
+## Example Usage
+
+```terraform
+data "onepassword_items" "secrets" {
+  vault  = "your-vault-id"
+  titles = ["DB_PASSWORD", "API_KEY", "JWT_SECRET"]
+}
+
+# Access individual credentials
+output "db_password" {
+  value     = data.onepassword_items.secrets.credentials["DB_PASSWORD"]
+  sensitive = true
+}
+
+# Access full item details
+output "api_key_category" {
+  value = data.onepassword_items.secrets.items["API_KEY"].category
+}
+```
+
+## Schema
+
+### Required
+
+- `vault` (String) The UUID of the vault the items are in.
+- `titles` (List of String) A list of item titles (or UUIDs) to retrieve from the vault.
+
+### Read-Only
+
+- `credentials` (Map of String, Sensitive) A map from item title to its primary credential value. For API credential items, this is the `credential` field. For all other items, this is the `password` field.
+- `id` (String) The Terraform resource identifier for this data source.
+- `items` (Attributes Map) A map from item title to item details. (see [below for nested schema](#nestedatt--items))
+
+<a id="nestedatt--items"></a>
+### Nested Schema for `items`
+
+Read-Only:
+
+- `category` (String) The category of the item.
+- `credential` (String, Sensitive) (Only applies to the API credential category) API credential for this item.
+- `id` (String) The UUID of the item.
+- `note_value` (String, Sensitive) Secure Note value.
+- `password` (String, Sensitive) Password for this item.
+- `tags` (List of String) An array of strings of the tags assigned to the item.
+- `title` (String) The title of the item.
+- `url` (String) The primary URL for the item.
+- `username` (String) Username for this item.

--- a/internal/onepassword/client.go
+++ b/internal/onepassword/client.go
@@ -18,6 +18,7 @@ type Client interface {
 	CreateItem(ctx context.Context, item *model.Item, vaultUuid string) (*model.Item, error)
 	UpdateItem(ctx context.Context, item *model.Item, vaultUuid string) (*model.Item, error)
 	DeleteItem(ctx context.Context, item *model.Item, vaultUuid string) error
+	GetItems(ctx context.Context, vaultUUID string, itemTitlesOrIDs []string) ([]*model.Item, error)
 	GetFileContent(ctx context.Context, file *model.ItemFile, itemUUid, vaultUuid string) ([]byte, error)
 	// GetEnvironmentVariables reads variables from a 1Password Environment. Only supported when using the 1Password SDK (service account or desktop app); not supported with 1Password Connect.
 	GetEnvironmentVariables(ctx context.Context, environmentID string) ([]model.EnvironmentVariable, error)

--- a/internal/onepassword/connect/connect_client.go
+++ b/internal/onepassword/connect/connect_client.go
@@ -113,6 +113,18 @@ func (c *Client) GetItemByTitle(_ context.Context, title string, vaultUuid strin
 	return modelItem, nil
 }
 
+func (c *Client) GetItems(ctx context.Context, vaultUUID string, itemTitlesOrIDs []string) ([]*model.Item, error) {
+	items := make([]*model.Item, 0, len(itemTitlesOrIDs))
+	for _, titleOrID := range itemTitlesOrIDs {
+		item, err := c.GetItem(ctx, titleOrID, vaultUUID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get item %q: %w", titleOrID, err)
+		}
+		items = append(items, item)
+	}
+	return items, nil
+}
+
 func (c *Client) CreateItem(ctx context.Context, item *model.Item, vaultUuid string) (*model.Item, error) {
 	// Convert model Item to Connect Item
 	connectItem, err := item.FromModelItemToConnect()

--- a/internal/onepassword/sdk/client.go
+++ b/internal/onepassword/sdk/client.go
@@ -123,6 +123,100 @@ func (c *Client) GetItemByTitle(ctx context.Context, title string, vaultUuid str
 	return modelItem, nil
 }
 
+func (c *Client) GetItems(ctx context.Context, vaultUUID string, itemTitlesOrIDs []string) ([]*model.Item, error) {
+	resolvedVaultUUID, err := c.resolveVaultUUID(ctx, vaultUUID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Separate UUIDs from titles
+	var ids []string
+	var titles []string
+	// Track the original index for each ID so we can return items in order
+	idOrder := make(map[string][]int)
+	for i, v := range itemTitlesOrIDs {
+		if util.IsValidUUID(v) {
+			ids = append(ids, v)
+			idOrder[v] = append(idOrder[v], i)
+		} else {
+			titles = append(titles, v)
+		}
+	}
+
+	// Resolve titles to IDs if any titles were provided
+	if len(titles) > 0 {
+		overviews, err := c.sdkClient.Items().List(ctx, resolvedVaultUUID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list items for title resolution: %w", err)
+		}
+
+		titleToID := make(map[string]string, len(titles))
+		titleCounts := make(map[string]int, len(titles))
+		titleSet := make(map[string]bool, len(titles))
+		for _, t := range titles {
+			titleSet[t] = true
+		}
+		for _, overview := range overviews {
+			if titleSet[overview.Title] {
+				titleToID[overview.Title] = overview.ID
+				titleCounts[overview.Title]++
+			}
+		}
+
+		for i, title := range itemTitlesOrIDs {
+			if util.IsValidUUID(title) {
+				continue
+			}
+			count := titleCounts[title]
+			if count == 0 {
+				return nil, fmt.Errorf("found 0 item(s) in vault %q with title %q", vaultUUID, title)
+			}
+			if count > 1 {
+				return nil, fmt.Errorf("found %d item(s) in vault %q with title %q", count, vaultUUID, title)
+			}
+			resolvedID := titleToID[title]
+			ids = append(ids, resolvedID)
+			idOrder[resolvedID] = append(idOrder[resolvedID], i)
+		}
+	}
+
+	// Batch fetch all items by ID
+	response, err := c.sdkClient.Items().GetAll(ctx, resolvedVaultUUID, ids)
+	if err != nil {
+		return nil, fmt.Errorf("failed to batch get items using sdk: %w", err)
+	}
+
+	// Build a map of ID -> model.Item from the response
+	fetchedItems := make(map[string]*model.Item, len(response.IndividualResponses))
+	for i, resp := range response.IndividualResponses {
+		if resp.Error != nil {
+			return nil, fmt.Errorf("failed to get item %q: %s", ids[i], resp.Error.Type)
+		}
+		if resp.Content == nil {
+			return nil, fmt.Errorf("failed to get item %q: empty response", ids[i])
+		}
+		modelItem := &model.Item{}
+		if err := modelItem.FromSDKItemToModel(resp.Content); err != nil {
+			return nil, fmt.Errorf("failed to convert item %q: %w", ids[i], err)
+		}
+		fetchedItems[ids[i]] = modelItem
+	}
+
+	// Reassemble in original order
+	items := make([]*model.Item, len(itemTitlesOrIDs))
+	for id, indices := range idOrder {
+		item, ok := fetchedItems[id]
+		if !ok {
+			return nil, fmt.Errorf("item %q not found in batch response", id)
+		}
+		for _, idx := range indices {
+			items[idx] = item
+		}
+	}
+
+	return items, nil
+}
+
 func (c *Client) CreateItem(ctx context.Context, item *model.Item, vaultUuid string) (*model.Item, error) {
 	params := item.FromModelItemToSDKCreateParams()
 

--- a/internal/provider/onepassword_items_data_source.go
+++ b/internal/provider/onepassword_items_data_source.go
@@ -1,0 +1,233 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	"github.com/1Password/terraform-provider-onepassword/v2/internal/onepassword"
+	"github.com/1Password/terraform-provider-onepassword/v2/internal/onepassword/model"
+)
+
+var _ datasource.DataSource = &OnePasswordItemsDataSource{}
+
+func NewOnePasswordItemsDataSource() datasource.DataSource {
+	return &OnePasswordItemsDataSource{}
+}
+
+type OnePasswordItemsDataSource struct {
+	client onepassword.Client
+}
+
+type OnePasswordItemsDataSourceModel struct {
+	ID          types.String                                  `tfsdk:"id"`
+	Vault       types.String                                  `tfsdk:"vault"`
+	Titles      []types.String                                `tfsdk:"titles"`
+	Items       map[string]OnePasswordItemsEntryModel         `tfsdk:"items"`
+	Credentials map[string]types.String                       `tfsdk:"credentials"`
+}
+
+type OnePasswordItemsEntryModel struct {
+	ID         types.String `tfsdk:"id"`
+	Title      types.String `tfsdk:"title"`
+	Category   types.String `tfsdk:"category"`
+	Credential types.String `tfsdk:"credential"`
+	Username   types.String `tfsdk:"username"`
+	Password   types.String `tfsdk:"password"`
+	NoteValue  types.String `tfsdk:"note_value"`
+	URL        types.String `tfsdk:"url"`
+	Tags       types.List   `tfsdk:"tags"`
+}
+
+func (d *OnePasswordItemsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_items"
+}
+
+func (d *OnePasswordItemsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Use this to batch-read multiple items from a vault. Returns item details and a convenience credentials map.",
+
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				MarkdownDescription: terraformItemIDDescription,
+				Computed:            true,
+			},
+			"vault": schema.StringAttribute{
+				MarkdownDescription: vaultUUIDDescription,
+				Required:            true,
+			},
+			"titles": schema.ListAttribute{
+				MarkdownDescription: "A list of item titles (or UUIDs) to retrieve from the vault.",
+				Required:            true,
+				ElementType:         types.StringType,
+			},
+			"items": schema.MapNestedAttribute{
+				MarkdownDescription: "A map from item title to item details.",
+				Computed:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							MarkdownDescription: itemUUIDDescription,
+							Computed:            true,
+						},
+						"title": schema.StringAttribute{
+							MarkdownDescription: itemTitleDescription,
+							Computed:            true,
+						},
+						"category": schema.StringAttribute{
+							MarkdownDescription: categoryDescription,
+							Computed:            true,
+						},
+						"credential": schema.StringAttribute{
+							MarkdownDescription: credentialDescription,
+							Computed:            true,
+							Sensitive:           true,
+						},
+						"username": schema.StringAttribute{
+							MarkdownDescription: usernameDescription,
+							Computed:            true,
+						},
+						"password": schema.StringAttribute{
+							MarkdownDescription: passwordDescription,
+							Computed:            true,
+							Sensitive:           true,
+						},
+						"note_value": schema.StringAttribute{
+							MarkdownDescription: noteValueDescription,
+							Computed:            true,
+							Sensitive:           true,
+						},
+						"url": schema.StringAttribute{
+							MarkdownDescription: urlDescription,
+							Computed:            true,
+						},
+						"tags": schema.ListAttribute{
+							MarkdownDescription: tagsDescription,
+							Computed:            true,
+							ElementType:         types.StringType,
+						},
+					},
+				},
+			},
+			"credentials": schema.MapAttribute{
+				MarkdownDescription: "A map from item title to its primary credential value (password or API credential). This is the most commonly needed secret value for each item.",
+				Computed:            true,
+				Sensitive:           true,
+				ElementType:         types.StringType,
+			},
+		},
+	}
+}
+
+func (d *OnePasswordItemsDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(onepassword.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected onepassword.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.client = client
+}
+
+func (d *OnePasswordItemsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data OnePasswordItemsDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	titles := make([]string, len(data.Titles))
+	for i, t := range data.Titles {
+		titles[i] = t.ValueString()
+	}
+
+	items, err := d.client.GetItems(ctx, data.Vault.ValueString(), titles)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read items, got error: %s", err))
+		return
+	}
+
+	itemsMap := make(map[string]OnePasswordItemsEntryModel, len(items))
+	credentialsMap := make(map[string]types.String, len(items))
+
+	for _, item := range items {
+		entry := OnePasswordItemsEntryModel{
+			ID:       types.StringValue(item.ID),
+			Title:    types.StringValue(item.Title),
+			Category: types.StringValue(strings.ToLower(string(item.Category))),
+		}
+
+		var primaryURL string
+		for _, u := range item.URLs {
+			if u.Primary {
+				primaryURL = u.URL
+			}
+		}
+		entry.URL = types.StringValue(primaryURL)
+
+		tags, diag := types.ListValueFrom(ctx, types.StringType, item.Tags)
+		resp.Diagnostics.Append(diag...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		entry.Tags = tags
+
+		var credential, username, password, noteValue string
+		for _, f := range item.Fields {
+			switch f.Purpose {
+			case model.FieldPurposeUsername:
+				username = f.Value
+			case model.FieldPurposePassword:
+				password = f.Value
+			case model.FieldPurposeNotes:
+				noteValue = f.Value
+			default:
+				if f.SectionID == "" {
+					switch f.ID {
+					case "username":
+						username = f.Value
+					case "password":
+						password = f.Value
+					case "credential":
+						credential = f.Value
+					}
+				}
+			}
+		}
+
+		entry.Username = types.StringValue(username)
+		entry.Password = types.StringValue(password)
+		entry.Credential = types.StringValue(credential)
+		entry.NoteValue = types.StringValue(noteValue)
+
+		itemsMap[item.Title] = entry
+
+		// credentials map: prefer credential (API cred), fall back to password
+		if credential != "" {
+			credentialsMap[item.Title] = types.StringValue(credential)
+		} else {
+			credentialsMap[item.Title] = types.StringValue(password)
+		}
+	}
+
+	data.Items = itemsMap
+	data.Credentials = credentialsMap
+	data.ID = types.StringValue(fmt.Sprintf("vaults/%s/items", data.Vault.ValueString()))
+
+	tflog.Trace(ctx, "read items data source")
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/provider/onepassword_items_data_source_test.go
+++ b/internal/provider/onepassword_items_data_source_test.go
@@ -1,0 +1,216 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/1Password/connect-sdk-go/onepassword"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/1Password/terraform-provider-onepassword/v2/internal/onepassword/model"
+)
+
+func setupTestServerMultipleItems(expectedItems []*model.Item, expectedVault model.Vault, t *testing.T) *httptest.Server {
+	t.Helper()
+
+	connectItems := make(map[string]*onepassword.Item, len(expectedItems))
+	connectItemBytes := make(map[string][]byte, len(expectedItems))
+
+	var connectItemList []*onepassword.Item
+
+	for _, item := range expectedItems {
+		connectItem, err := item.FromModelItemToConnect()
+		if err != nil {
+			t.Fatalf("error converting item to connect item: %s", err)
+		}
+		connectItems[item.ID] = connectItem
+		connectItemList = append(connectItemList, connectItem)
+
+		itemBytes, err := json.Marshal(connectItem)
+		if err != nil {
+			t.Fatalf("error marshaling item for testing: %s", err)
+		}
+		connectItemBytes[item.ID] = itemBytes
+	}
+
+	connectVault := expectedVault.ToConnectVault()
+	vaultBytes, err := json.Marshal(connectVault)
+	if err != nil {
+		t.Fatalf("error marshaling vault for testing: %s", err)
+	}
+
+	itemListBytes, err := json.Marshal(connectItemList)
+	if err != nil {
+		t.Fatalf("error marshaling itemlist for testing: %s", err)
+	}
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Unexpected method: %s", r.Method)
+			return
+		}
+
+		// Match /v1/vaults/{vaultID}/items/{itemID}
+		for _, item := range expectedItems {
+			if r.URL.String() == fmt.Sprintf("/v1/vaults/%s/items/%s", expectedVault.ID, item.ID) {
+				w.WriteHeader(http.StatusOK)
+				w.Header().Set("Content-Type", "application/json")
+				_, err := w.Write(connectItemBytes[item.ID])
+				if err != nil {
+					t.Errorf("error writing body: %s", err)
+				}
+				return
+			}
+		}
+
+		if r.URL.String() == fmt.Sprintf("/v1/vaults/%s", expectedVault.ID) {
+			w.Header().Set("Content-Type", "application/json")
+			_, err := w.Write(vaultBytes)
+			if err != nil {
+				t.Errorf("error writing body: %s", err)
+			}
+			return
+		}
+
+		if r.URL.String() == fmt.Sprintf("/v1/vaults/%s/items", expectedVault.ID) {
+			w.Header().Set("Content-Type", "application/json")
+			_, err := w.Write(itemListBytes)
+			if err != nil {
+				t.Errorf("error writing body: %s", err)
+			}
+			return
+		}
+
+		t.Errorf("Unexpected request: %s", r.URL.String())
+	}))
+}
+
+func TestAccItemsDataSourceBatchRead(t *testing.T) {
+	loginItem := generateLoginItem()
+	loginItem.ID = "abcdefghijklmnopqrstuvwx01"
+	loginItem.Title = "Login Secret"
+
+	passwordItem := generatePasswordItem()
+	passwordItem.ID = "abcdefghijklmnopqrstuvwx02"
+	passwordItem.Title = "Password Secret"
+
+	expectedVault := model.Vault{
+		ID:          loginItem.VaultID,
+		Name:        "Name of the vault",
+		Description: "This vault will be retrieved",
+	}
+
+	testServer := setupTestServerMultipleItems([]*model.Item{loginItem, passwordItem}, expectedVault, t)
+	defer testServer.Close()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig(testServer.URL) + testAccItemsDataSourceConfig(expectedVault.ID, loginItem.ID, passwordItem.ID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.onepassword_items.test", "vault", expectedVault.ID),
+					resource.TestCheckResourceAttr("data.onepassword_items.test", "items.Login Secret.id", loginItem.ID),
+					resource.TestCheckResourceAttr("data.onepassword_items.test", "items.Login Secret.title", loginItem.Title),
+					resource.TestCheckResourceAttr("data.onepassword_items.test", "items.Login Secret.category", strings.ToLower(string(loginItem.Category))),
+					resource.TestCheckResourceAttr("data.onepassword_items.test", "items.Login Secret.username", loginItem.Fields[0].Value),
+					resource.TestCheckResourceAttr("data.onepassword_items.test", "items.Login Secret.password", loginItem.Fields[1].Value),
+					resource.TestCheckResourceAttr("data.onepassword_items.test", "items.Password Secret.id", passwordItem.ID),
+					resource.TestCheckResourceAttr("data.onepassword_items.test", "items.Password Secret.title", passwordItem.Title),
+					resource.TestCheckResourceAttr("data.onepassword_items.test", "items.Password Secret.category", strings.ToLower(string(passwordItem.Category))),
+					resource.TestCheckResourceAttr("data.onepassword_items.test", "credentials.Login Secret", loginItem.Fields[1].Value),
+					resource.TestCheckResourceAttr("data.onepassword_items.test", "credentials.Password Secret", passwordItem.Fields[1].Value),
+				),
+			},
+		},
+	})
+}
+
+func TestAccItemsDataSourceMixedCategories(t *testing.T) {
+	loginItem := generateLoginItem()
+	loginItem.ID = "abcdefghijklmnopqrstuvwx03"
+	loginItem.Title = "My Login"
+
+	apiCredItem := generateApiCredentialItem()
+	apiCredItem.ID = "abcdefghijklmnopqrstuvwx04"
+	apiCredItem.Title = "My API Key"
+
+	passwordItem := generatePasswordItem()
+	passwordItem.ID = "abcdefghijklmnopqrstuvwx05"
+	passwordItem.Title = "My Password"
+
+	expectedVault := model.Vault{
+		ID:          loginItem.VaultID,
+		Name:        "Name of the vault",
+		Description: "This vault will be retrieved",
+	}
+
+	testServer := setupTestServerMultipleItems([]*model.Item{loginItem, apiCredItem, passwordItem}, expectedVault, t)
+	defer testServer.Close()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig(testServer.URL) + testAccItemsDataSourceConfig(expectedVault.ID, loginItem.ID, apiCredItem.ID, passwordItem.ID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.onepassword_items.test", "items.My Login.category", "login"),
+					resource.TestCheckResourceAttr("data.onepassword_items.test", "items.My API Key.category", "api_credential"),
+					resource.TestCheckResourceAttr("data.onepassword_items.test", "items.My Password.category", "password"),
+					// credentials map: API credential uses credential field, others use password
+					resource.TestCheckResourceAttr("data.onepassword_items.test", "credentials.My Login", loginItem.Fields[1].Value),
+					resource.TestCheckResourceAttr("data.onepassword_items.test", "credentials.My API Key", apiCredItem.Fields[1].Value), // credential field
+					resource.TestCheckResourceAttr("data.onepassword_items.test", "credentials.My Password", passwordItem.Fields[1].Value),
+				),
+			},
+		},
+	})
+}
+
+func TestAccItemsDataSourceSingleItem(t *testing.T) {
+	loginItem := generateLoginItem()
+	loginItem.ID = "abcdefghijklmnopqrstuvwx06"
+	loginItem.Title = "Solo Item"
+
+	expectedVault := model.Vault{
+		ID:          loginItem.VaultID,
+		Name:        "Name of the vault",
+		Description: "This vault will be retrieved",
+	}
+
+	testServer := setupTestServerMultipleItems([]*model.Item{loginItem}, expectedVault, t)
+	defer testServer.Close()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig(testServer.URL) + fmt.Sprintf(`
+data "onepassword_items" "test" {
+  vault  = "%s"
+  titles = ["%s"]
+}`, expectedVault.ID, loginItem.ID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.onepassword_items.test", "items.Solo Item.id", loginItem.ID),
+					resource.TestCheckResourceAttr("data.onepassword_items.test", "credentials.Solo Item", loginItem.Fields[1].Value),
+				),
+			},
+		},
+	})
+}
+
+func testAccItemsDataSourceConfig(vault string, uuids ...string) string {
+	quoted := make([]string, len(uuids))
+	for i, u := range uuids {
+		quoted[i] = fmt.Sprintf("%q", u)
+	}
+	return fmt.Sprintf(`
+data "onepassword_items" "test" {
+  vault  = "%s"
+  titles = [%s]
+}`, vault, strings.Join(quoted, ", "))
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -188,6 +188,7 @@ func (p *OnePasswordProvider) EphemeralResources(ctx context.Context) []func() e
 func (p *OnePasswordProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
 		NewOnePasswordItemDataSource,
+		NewOnePasswordItemsDataSource,
 		NewOnePasswordVaultDataSource,
 		NewOnePasswordEnvironmentDataSource,
 	}


### PR DESCRIPTION
## Summary

Adds a new `onepassword_items` (plural) data source that reads multiple items from a vault in a single Terraform data block. This reduces configuration boilerplate and API calls when modules need 10-20+ secrets.

Closes #363

## Details

- **SDK backend**: Resolves titles via `Items().List()`, then batch-fetches with `Items().GetAll()` -- two API calls total regardless of item count
- **Connect backend**: Falls back to sequential `GetItem()` calls (Connect has no batch API)
- Adds `GetItems(ctx, vaultUUID, titlesOrIDs)` to the `Client` interface
- `titles` field accepts both titles and UUIDs (detected via format)
- Includes a `credentials` convenience map (title -> primary secret value)
- Exposes top-level fields only (no sections or file attachments) as a first pass

## Usage

```hcl
data "onepassword_items" "secrets" {
  vault  = var.vault_id
  titles = ["DB_PASSWORD", "API_KEY", "OAUTH_SECRET"]
}

output "db_password" {
  value     = data.onepassword_items.secrets.credentials["DB_PASSWORD"]
  sensitive = true
}
```

## Open questions

1. Should `titles` accepting UUIDs be split into separate attributes?
2. Is the `credentials` convenience map too opinionated, or useful enough to keep?
3. Is top-level fields only a reasonable scope for v1?