### PR TITLE
ci: add setup-terraform to build and e2e jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,11 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_wrapper: false
+
       - name: Build
         run: go build -v ./...
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -33,6 +33,11 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_wrapper: false
+
       - name: Create kind cluster
         uses: helm/kind-action@v1
 
@@ -92,6 +97,11 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_wrapper: false
 
       - name: Install dependencies
         run: go mod tidy


### PR DESCRIPTION
### ✨ Summary

Add the hashicorp/setup-terraform action to the Build and Test workflow and to both jobs in the E2E workflow, matching how Verify Docs already installs Terraform.

Our CI runs Terraform acceptance tests which need a terraform binary. The runners don’t ship Terraform, so the test tooling tried to download it and verify HashiCorp’s release signatures. That check started failing because the HashiCorp GPG key used for those signatures expired. Installing Terraform in the workflow avoids that download and verify path, so tests use a normal CLI install instead.

Build and Test and E2E now pass.

### 🔗 Resolves:

<!-- What issue does it resolve? -->

### ✅ Checklist

- [x] 🖊️ Commits are signed
- [ ] 🧪 Tests added/updated: _(See the [Testing Guide](docs/testing/testing.md) for when to use each type and how to run them)_
  - [ ] 🔹 Unit /🔸 Integration
  - [ ] 🌐 E2E
- [ ] 📚 Docs updated (if behavior changed)

### 🕵️ Review Notes & ⚠️ Risks

<!-- Notes for reviewers, flags, feature gates, rollout considerations, etc. -->
