### PR TITLE
feat(resource): support API Credential category in resources

### DIFF
--- a/docs/data-sources/item.md
+++ b/docs/data-sources/item.md
@@ -35,7 +35,7 @@ data "onepassword_item" "example" {
 
 ### Read-Only
 
-- `category` (String) The category of the item. One of ["login" "password" "database" "secure_note" "document" "ssh_key" "api_credential"]
+- `category` (String) The category of the item. One of ["login" "password" "secure_note" "document" "ssh_key" "database" "api_credential"]
 - `credential` (String, Sensitive) (Only applies to the API credential category) API credential for this item.
 - `database` (String) (Only applies to the database category) The name of the database.
 - `file` (Block List) A list of files attached to the document item. (see [below for nested schema](#nestedblock--file))

--- a/docs/resources/item.md
+++ b/docs/resources/item.md
@@ -83,7 +83,7 @@ resource "onepassword_item" "example_with_list" {
 
 > **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
 
-- `category` (String) The category of the item. One of ["login" "password" "database" "secure_note"]
+- `category` (String) The category of the item. One of ["login" "password" "secure_note" "document" "ssh_key" "database" "api_credential"]
 - `database` (String) (Only applies to the database category) The name of the database.
 - `hostname` (String) (Only applies to the database category) The address where the database can be found
 - `note_value` (String, Sensitive) Secure Note value.

--- a/internal/onepassword/model/item.go
+++ b/internal/onepassword/model/item.go
@@ -623,12 +623,13 @@ func toModelFieldType(filedType sdk.ItemFieldType) ItemFieldType {
 }
 
 var modelToSDKCategoryMap = map[ItemCategory]sdk.ItemCategory{
-	Login:      sdk.ItemCategoryLogin,
-	Password:   sdk.ItemCategoryPassword,
-	SecureNote: sdk.ItemCategorySecureNote,
-	Document:   sdk.ItemCategoryDocument,
-	SSHKey:     sdk.ItemCategorySSHKey,
-	Database:   sdk.ItemCategoryDatabase,
+	Login:         sdk.ItemCategoryLogin,
+	Password:      sdk.ItemCategoryPassword,
+	SecureNote:    sdk.ItemCategorySecureNote,
+	Document:      sdk.ItemCategoryDocument,
+	SSHKey:        sdk.ItemCategorySSHKey,
+	Database:      sdk.ItemCategoryDatabase,
+	APICredential: sdk.ItemCategoryAPICredentials,
 }
 
 func fromModelCategoryToSDK(itemCategory ItemCategory) sdk.ItemCategory {

--- a/internal/onepassword/model/item_test.go
+++ b/internal/onepassword/model/item_test.go
@@ -41,6 +41,10 @@ func TestFromModelCategoryToSDK(t *testing.T) {
 			input:    Database,
 			expected: sdk.ItemCategoryDatabase,
 		},
+		"should convert APICredential category": {
+			input:    APICredential,
+			expected: sdk.ItemCategoryAPICredentials,
+		},
 		"should return zero value for unknown category": {
 			input:    ItemCategory("UNKNOWN"),
 			expected: sdk.ItemCategory(""),
@@ -85,6 +89,10 @@ func TestFromSDKCategoryToModel(t *testing.T) {
 		"should convert Database category": {
 			input:    sdk.ItemCategoryDatabase,
 			expected: Database,
+		},
+		"should convert APICredential category": {
+			input:    sdk.ItemCategoryAPICredentials,
+			expected: APICredential,
 		},
 		"should return zero value for unknown category": {
 			input:    sdk.ItemCategory("UNKNOWN"),
@@ -217,6 +225,7 @@ func TestCategoryConversionRoundTrip(t *testing.T) {
 		Document,
 		SSHKey,
 		Database,
+		APICredential,
 	}
 
 	for _, category := range categories {

--- a/internal/provider/const.go
+++ b/internal/provider/const.go
@@ -79,11 +79,11 @@ var (
 		strings.ToLower(string(model.Password)),
 		strings.ToLower(string(model.Database)),
 		strings.ToLower(string(model.SecureNote)),
+		strings.ToLower(string(model.APICredential)),
 	}
 	dataSourceCategories = append(categories,
 		strings.ToLower(string(model.Document)),
 		strings.ToLower(string(model.SSHKey)),
-		strings.ToLower(string(model.APICredential)),
 	)
 
 	fieldPurposes = []string{

--- a/internal/provider/const.go
+++ b/internal/provider/const.go
@@ -38,7 +38,6 @@ const (
 	dbHostnameDescription = "(Only applies to the database category) The address where the database can be found"
 	dbDatabaseDescription = "(Only applies to the database category) The name of the database."
 	dbPortDescription     = "(Only applies to the database category) The port the database is listening on."
-	dbTypeDescription     = "(Only applies to the database category) The type of database."
 	typeDescription       = "(Only applies to database and API credential categories) The type of database or API Credential."
 
 	sectionListDescription  = "A list of custom sections in an item. Cannot be used together with `section_map`. Use either `section` (list) or `section_map` (map), but not both."
@@ -72,7 +71,8 @@ const (
 )
 
 var (
-	dbTypes = []string{"db2", "filemaker", "msaccess", "mssql", "mysql", "oracle", "postgresql", "sqlite", "other"}
+	dbTypes            = []string{"db2", "filemaker", "msaccess", "mssql", "mysql", "oracle", "postgresql", "sqlite", "other"}
+	apiCredentialTypes = []string{"bearer", "json", "jwt", "other"}
 
 	categories = []string{
 		strings.ToLower(string(model.Login)),

--- a/internal/provider/onepassword_item_resource.go
+++ b/internal/provider/onepassword_item_resource.go
@@ -60,6 +60,9 @@ type OnePasswordItemResourceModel struct {
 	NoteValue          types.String                                      `tfsdk:"note_value"`
 	NoteValueWO        types.String                                      `tfsdk:"note_value_wo"`
 	NoteValueWOVersion types.Int64                                       `tfsdk:"note_value_wo_version"`
+	Credential         types.String                                      `tfsdk:"credential"`
+	Filename           types.String                                      `tfsdk:"filename"`
+	ValidFrom          types.String                                      `tfsdk:"valid_from"`
 	SectionList        []OnePasswordItemResourceSectionListModel         `tfsdk:"section"`
 	SectionMap         map[string]OnePasswordItemResourceSectionMapModel `tfsdk:"section_map"`
 	Recipe             []PasswordRecipeModel                             `tfsdk:"password_recipe"`
@@ -363,6 +366,19 @@ func (r *OnePasswordItemResource) Schema(ctx context.Context, req resource.Schem
 						path.Expressions{path.MatchRoot("note_value_wo")}...,
 					),
 				},
+			},
+			"credential": schema.StringAttribute{
+				MarkdownDescription: credentialDescription,
+				Optional:            true,
+				Sensitive:           true,
+			},
+			"filename": schema.StringAttribute{
+				MarkdownDescription: filenameDescription,
+				Optional:            true,
+			},
+			"valid_from": schema.StringAttribute{
+				MarkdownDescription: validFromDescription,
+				Optional:            true,
 			},
 			"section_map": schema.MapNestedAttribute{
 				MarkdownDescription: sectionMapDescription,
@@ -762,6 +778,9 @@ func stateToModel(ctx context.Context, state OnePasswordItemResourceModel) (*mod
 	case "secure_note":
 		modelItem.Category = model.SecureNote
 		modelItem.Fields = toModelSecureNoteFields(state)
+	case "api_credential":
+		modelItem.Category = model.APICredential
+		modelItem.Fields = toModelApiCredentialFields(state)
 	}
 
 	tags, diagnostics := toModelTags(ctx, state)

--- a/internal/provider/onepassword_item_resource.go
+++ b/internal/provider/onepassword_item_resource.go
@@ -285,10 +285,10 @@ func (r *OnePasswordItemResource) Schema(ctx context.Context, req resource.Schem
 				Optional:            true,
 			},
 			"type": schema.StringAttribute{
-				MarkdownDescription: fmt.Sprintf(enumDescription, dbTypeDescription, dbTypes),
+				MarkdownDescription: typeDescription,
 				Optional:            true,
 				Validators: []validator.String{
-					stringvalidator.OneOfCaseInsensitive(dbTypes...),
+					validateType(),
 				},
 			},
 			"tags": schema.ListAttribute{

--- a/internal/provider/onepassword_item_resource_test.go
+++ b/internal/provider/onepassword_item_resource_test.go
@@ -180,6 +180,38 @@ func TestAccItemResourceDocument(t *testing.T) {
 	})
 }
 
+func TestAccItemResourceApiCredential(t *testing.T) {
+	expectedItem := generateApiCredentialItem()
+	expectedVault := model.Vault{
+		ID:          expectedItem.VaultID,
+		Name:        "VaultName",
+		Description: "This vault will be retrieved for testing",
+	}
+
+	testServer := setupTestServer(expectedItem, expectedVault, t)
+	defer testServer.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig(testServer.URL) + testAccApiCredentialResourceConfig(expectedItem),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// verify local values
+					resource.TestCheckResourceAttr("onepassword_item.test-api", "title", expectedItem.Title),
+					resource.TestCheckResourceAttr("onepassword_item.test-api", "category", strings.ToLower(string(expectedItem.Category))),
+					resource.TestCheckResourceAttr("onepassword_item.test-api", "username", expectedItem.Fields[0].Value),
+					resource.TestCheckResourceAttr("onepassword_item.test-api", "credential", expectedItem.Fields[1].Value),
+					resource.TestCheckResourceAttr("onepassword_item.test-api", "type", expectedItem.Fields[2].Value),
+					resource.TestCheckResourceAttr("onepassword_item.test-api", "filename", expectedItem.Fields[3].Value),
+					resource.TestCheckResourceAttr("onepassword_item.test-api", "valid_from", expectedItem.Fields[4].Value),
+					resource.TestCheckResourceAttr("onepassword_item.test-api", "hostname", expectedItem.Fields[5].Value),
+				),
+			},
+		},
+	})
+}
+
 func TestAccItemResource_PasswordWriteOnly(t *testing.T) {
 	expectedItem := generatePasswordItem()
 	expectedVault := model.Vault{
@@ -500,6 +532,25 @@ resource "onepassword_item" "test-document" {
   title = "%s"
   category = "%s"
 }`, expectedItem.VaultID, expectedItem.Title, strings.ToLower(string(expectedItem.Category)))
+}
+
+func testAccApiCredentialResourceConfig(expectedItem *model.Item) string {
+	return fmt.Sprintf(`
+
+data "onepassword_vault" "acceptance-tests" {
+	uuid = "%s"
+}
+resource "onepassword_item" "test-api" {
+  vault = data.onepassword_vault.acceptance-tests.uuid
+  title = "%s"
+  category = "%s"
+  username = "%s"
+  credential = "%s"
+  type = "%s"
+  filename = "%s"
+  valid_from = "%s"
+  hostname = "%s"
+}`, expectedItem.VaultID, expectedItem.Title, strings.ToLower(string(expectedItem.Category)), expectedItem.Fields[0].Value, expectedItem.Fields[1].Value, expectedItem.Fields[2].Value, expectedItem.Fields[3].Value, expectedItem.Fields[4].Value, expectedItem.Fields[5].Value)
 }
 
 func testAccResourceWithSectionsConfig(expectedItem *model.Item) string {

--- a/internal/provider/state_to_model.go
+++ b/internal/provider/state_to_model.go
@@ -110,6 +110,47 @@ func toModelDatabaseFields(state OnePasswordItemResourceModel, password string, 
 	}
 }
 
+func toModelApiCredentialFields(state OnePasswordItemResourceModel) []model.ItemField {
+	return []model.ItemField{
+		{
+			ID:    "username",
+			Label: "username",
+			Type:  model.FieldTypeString,
+			Value: state.Username.ValueString(),
+		},
+		{
+			ID:    "credential",
+			Label: "credential",
+			Type:  model.FieldTypeConcealed,
+			Value: state.Credential.ValueString(),
+		},
+		{
+			ID:    "credential_type",
+			Label: "type",
+			Type:  model.FieldTypeString,
+			Value: state.Type.ValueString(),
+		},
+		{
+			ID:    "filename",
+			Label: "filename",
+			Type:  model.FieldTypeString,
+			Value: state.Filename.ValueString(),
+		},
+		{
+			ID:    "validFrom",
+			Label: "valid_from",
+			Type:  model.FieldTypeString,
+			Value: state.ValidFrom.ValueString(),
+		},
+		{
+			ID:    "hostname",
+			Label: "hostname",
+			Type:  model.FieldTypeString,
+			Value: state.Hostname.ValueString(),
+		},
+	}
+}
+
 func toModelSecureNoteFields(state OnePasswordItemResourceModel) []model.ItemField {
 	return []model.ItemField{
 		{

--- a/internal/provider/test_utils.go
+++ b/internal/provider/test_utils.go
@@ -206,7 +206,7 @@ func generateApiCredentialFields() []model.ItemField {
 		{
 			ID:    "type",
 			Label: "type",
-			Value: "test_type",
+			Value: "bearer",
 		},
 		{
 			ID:    "filename",

--- a/internal/provider/type_validator.go
+++ b/internal/provider/type_validator.go
@@ -1,0 +1,66 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func validateType() validator.String {
+	return typeValidator{}
+}
+
+type typeValidator struct{}
+
+func (v typeValidator) Description(_ context.Context) string {
+	return "Allowed type values are dependent on the item category."
+}
+
+func (v typeValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v typeValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	var category types.String
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("category"), &category)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if category.IsUnknown() {
+		return
+	}
+
+	val := req.ConfigValue.ValueString()
+
+	var allowed []string
+	switch strings.ToLower(category.ValueString()) {
+	case "database":
+		allowed = dbTypes
+	case "api_credential":
+		allowed = apiCredentialTypes
+	default:
+		// `type` is not meaningful for other categories; skip.
+		return
+	}
+
+	for _, a := range allowed {
+		if strings.EqualFold(a, val) {
+			return
+		}
+	}
+
+	resp.Diagnostics.AddAttributeError(
+		req.Path,
+		fmt.Sprintf("Invalid type for category %q", category),
+		fmt.Sprintf("Type for category %q must be one of %v, got: %q", category, allowed, val),
+	)
+}

--- a/test/e2e/item_resource_test.go
+++ b/test/e2e/item_resource_test.go
@@ -70,6 +70,18 @@ var testItemsToCreate = map[model.ItemCategory]testResourceItem{
 			"tags":       []string{"firstTestTag", "secondTestTag"},
 		},
 	},
+	model.APICredential: {
+		Attrs: map[string]any{
+			"title":      "Test API Credential Create",
+			"category":   "api_credential",
+			"credential": "testCredential",
+			"username":   "testAPICredential",
+			"hostname":   "testHostname",
+			"type":       "bearer",
+			"valid_from": "2026-01-01",
+			"filename":   "testFilename",
+		},
+	},
 }
 
 var testItemsUpdatedAttrs = map[model.ItemCategory]map[string]any{
@@ -106,6 +118,16 @@ var testItemsUpdatedAttrs = map[model.ItemCategory]map[string]any{
 		"note_value": "This is an updated secure note",
 		"tags":       []string{"firstUpdatedTestTag", "secondUpdatedTestTag"},
 	},
+	model.APICredential: {
+		"title":      "Test API Credential Create",
+		"category":   "api_credential",
+		"credential": "updatedTestCredential",
+		"username":   "updatedTestAPICredential",
+		"hostname":   "updatedTestHostname",
+		"type":       "bearer",
+		"valid_from": "2026-05-01",
+		"filename":   "updatedTestFilename",
+	},
 }
 
 func TestMain(m *testing.M) {
@@ -129,6 +151,7 @@ func TestAccItemResource(t *testing.T) {
 		{category: model.Password, name: "Password"},
 		{category: model.Database, name: "Database"},
 		{category: model.SecureNote, name: "SecureNote"},
+		{category: model.APICredential, name: "APICredential"},
 	}
 
 	testVaultID := vault.GetTestVaultID(t)


### PR DESCRIPTION
### ✨ Summary

This PR adds the `api_credential` category to the resource model for creation of API Credentials items. API credentials are already supported as a data source but lacked parity with resources.

Since the existing `type` field only supports database values, I've added a validator to differentiate based on the `category` field. The documentation has been updated as well.

### 🔗 Resolves:

#290 recently added support for API credential items via data sources, but the same item cannot be created with a resource. The following Terraform block fails to apply with the latest release:

```tf
resource "onepassword_item" "my_api" {
  vault = data.onepassword_vault.my_vault.uuid
  title = "My API Credentials"
  category = "api_credentials" // Attribute category value must be one of: ["login" "password" "database" "secure_note"], got: "api_credentials"
}
```

This change attempts to bring the resource model in line with the corresponding data source.

### ✅ Checklist

- [x] 🖊️ Commits are signed
- [x] 🧪 Tests added/updated: _(See the [Testing Guide](docs/testing/testing.md) for when to use each type and how to run them)_
  - [x] 🔹 Unit /🔸 Integration
  - [x] 🌐 E2E
- [x] 📚 Docs updated (if behavior changed)

### 🕵️ Review Notes & ⚠️ Risks

<!-- Notes for reviewers, flags, feature gates, rollout considerations, etc. -->
