### PR TITLE
Add Terms of Service to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 - See the [examples](./examples/) directory for detailed examples.
 - For more details check out [1Password Terraform Provider documentation](https://developer.1password.com/docs/terraform/).
 
+*By accessing or using 1Password Developer Tools, you agree to the [API and SDK Terms of Service](https://1password.com/legal/api-sdk-terms-of-service).*
+
 ```tf
 terraform {
   required_providers {
@@ -96,5 +98,3 @@ Still not sure where or how to begin? We're happy to help! You can join the [Dev
 1Password requests you practice responsible disclosure if you discover a vulnerability.
 
 Please file requests by sending an email to bugbounty@agilebits.com.
-
-*By accessing or using 1Password Developer Tools, you agree to the [API and SDK Terms of Service](https://1password.com/legal/api-sdk-terms-of-service).*

--- a/README.md
+++ b/README.md
@@ -96,3 +96,5 @@ Still not sure where or how to begin? We're happy to help! You can join the [Dev
 1Password requests you practice responsible disclosure if you discover a vulnerability.
 
 Please file requests by sending an email to bugbounty@agilebits.com.
+
+*By accessing or using 1Password Developer Tools, you agree to the [API and SDK Terms of Service](https://1password.com/legal/api-sdk-terms-of-service).*

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 - See the [examples](./examples/) directory for detailed examples.
 - For more details check out [1Password Terraform Provider documentation](https://developer.1password.com/docs/terraform/).
 
-*By accessing or using 1Password Developer Tools, you agree to the [API and SDK Terms of Service](https://1password.com/legal/api-sdk-terms-of-service).*
+*This project is licensed under [MIT](./LICENSE). Use of the 1Password APIs and services accessed through these tools is governed by the [1Password API Terms of Service](https://1password.com/legal/api-sdk-terms-of-service).*
 
 ```tf
 terraform {


### PR DESCRIPTION
### ✨ Summary

Adds Terms of Service to end of README, as requested by the legal team. This needs to merge on June 5th.

### 🔗 Resolves:

Relates to: https://1password.atlassian.net/browse/TW-1153

### ✅ Checklist

- [x] 🖊️ Commits are signed

### 🕵️ Review Notes & ⚠️ Risks

<!-- Notes for reviewers, flags, feature gates, rollout considerations, etc. -->
